### PR TITLE
Performance improvement: Ensures that routers sorting is being done only once in ChainRouter

### DIFF
--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -25,6 +25,11 @@ class ChainRouter implements RouterInterface, WarmableInterface
     private $context;
     private $logger;
 
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface[] Array of routers, sorted by priority
+     */
+    protected $sortedRouters;
+
     public function __construct(LoggerInterface $logger = null)
     {
         $this->logger = $logger;
@@ -53,6 +58,7 @@ class ChainRouter implements RouterInterface, WarmableInterface
         }
 
         $this->routers[$priority][] = $router;
+        $this->sortedRouters = array();
     }
 
     /**
@@ -62,14 +68,29 @@ class ChainRouter implements RouterInterface, WarmableInterface
      */
     public function all()
     {
-        krsort($this->routers);
-        $routers = array();
-
-        foreach ($this->routers as $all) {
-            $routers = array_merge($routers, $all);
+        if (empty($this->sortedRouters)) {
+            $this->sortedRouters = $this->sortRouters();
         }
 
-        return $routers;
+        return $this->sortedRouters;
+    }
+
+    /**
+     * Sort routers by priority.
+     * The highest priority number is the highest priority (reverse sorting)
+     *
+     * @return \Symfony\Component\Routing\RouterInterface[]
+     */
+    protected function sortRouters()
+    {
+        $sortedRouters = array();
+        krsort($this->routers);
+
+        foreach ($this->routers as $routers) {
+            $sortedRouters = array_merge($sortedRouters, $routers);
+        }
+
+        return $sortedRouters;
     }
 
     /**


### PR DESCRIPTION
As discussed earlier with @lsmith77, the `ChainRouter` needs performance improvement since the sorting operation is done every time the `all()` method is called. This can have a serious impact since this method is also called for link generation.

This pull request fixes it, and adds 2 tests to cover it.

Cheers from the [eZ Publish](https://github.com/ezsystems/ezpublish5) dev team :)
