### PR TITLE
Add a new interface ChainedRouterInterface with a `support` method

### DIFF
--- a/ChainedRouterInterface.php
+++ b/ChainedRouterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Cmf\Component\Routing;
+
+use Symfony\Component\Routing\RouterInterface;
+
+interface ChainedRouterInterface extends RouterInterface
+{
+    /**
+     * This method checks if the current router supports the passed object
+     *
+     * @param $name mixed The route name or route object
+     *
+     * @return bool
+     */
+    function supports($name);
+}

--- a/Tests/Routing/ChainRouterTest.php
+++ b/Tests/Routing/ChainRouterTest.php
@@ -483,6 +483,30 @@ class ChainRouterTest extends CmfUnitTestCase
         $this->assertEquals(array('high', 'low'), $names);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
+     */
+    public function testSupport()
+    {
+
+        $router = $this->getMock('Symfony\Cmf\Component\Routing\ChainedRouterInterface');
+        $router
+            ->expects($this->once())
+            ->method('supports')
+            ->will($this->returnValue(false))
+        ;
+
+        $router
+            ->expects($this->never())
+            ->method('generate')
+            ->will($this->returnValue(false))
+        ;
+
+        $this->router->add($router);
+
+        $this->router->generate('foobar');
+    }
+
     protected function createRouterMocks()
     {
         return array(


### PR DESCRIPTION
This will allow to check if a router support a the current route
name. With the current workflow a route can be either a string
or an object (ie, a Page instance)
