### PR TITLE
Fixed #15 When using the chain router in a compiler pass, cache warmup fails

### DIFF
--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -224,13 +224,13 @@ class ChainRouter implements RouterInterface, RequestMatcherInterface, WarmableI
      */
     public function setContext(RequestContext $context)
     {
-        $this->context = $context;
-
         foreach ($this->all() as $router) {
             if ($router instanceof RequestContextAwareInterface) {
                 $router->setContext($context);
             }
         }
+
+        $this->context = $context;
     }
 
     /**


### PR DESCRIPTION
# Origin of the issue

When warming up, base `UrlMatcher` / `UrlGenerator` are "cached" by the routing component. The **CMF ChainRouter** adds its routers in a compiler pass through its `add()` method. But calling this method triggers `setContext()` which triggers again `UrlMatcher` caching process, thus the collision and the fatal error.
# Proposed fix

As `add()` is called at compile/warmup time, the best solution would be to move the `setContext()` operation to a safer place, that is in `all()`, just after the routers has been sorted (only happens once, unless a new router is added on the fly).
