### PR TITLE
Chainrouter: don't pass non default string route names to default router

### DIFF
--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -199,10 +199,15 @@ class ChainRouter implements RouterInterface, RequestMatcherInterface, WarmableI
         /** @var $router ChainedRouterInterface */
         foreach ($this->all() as $router) {
 
-            if ($name && !is_string($name) && !$router instanceof ChainedRouterInterface ) {
-                continue;
+            // if $name and $router does not implement ChainedRouterInterface and $name is not a string, continue
+            // if $name and $router does not implement ChainedRouterInterface and $name is string but does not match a default Symfony2 route name, continue
+            if ($name && !$router instanceof ChainedRouterInterface) {
+                if (!is_string($name) || !preg_match('/^[a-z0-9A-Z_.]+$/', $name)) {
+                    continue;
+                }
             }
 
+            // If $router implements ChainedRouterInterface but doesn't support this route name, continue
             if ($router instanceof ChainedRouterInterface && !$router->supports($name)) {
                 continue;
             }

--- a/Tests/Routing/ChainRouterTest.php
+++ b/Tests/Routing/ChainRouterTest.php
@@ -428,6 +428,68 @@ class ChainRouterTest extends CmfUnitTestCase
         $this->assertEquals($url, $result);
     }
 
+    public function testGenerateObjectName()
+    {
+        $name = new \stdClass();
+        $parameters = array('test' => 'value');
+
+        $defaultRouter = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
+        $chainedRouter = $this->getMock('Symfony\\Cmf\\Component\\Routing\\ChainedRouterInterface');
+
+        $defaultRouter
+            ->expects($this->never())
+            ->method('generate')
+        ;
+        $chainedRouter
+            ->expects($this->once())
+            ->method('supports')
+            ->will($this->returnValue(true))
+        ;
+        $chainedRouter
+            ->expects($this->once())
+            ->method('generate')
+            ->with($name, $parameters, false)
+            ->will($this->returnValue($name))
+        ;
+
+        $this->router->add($defaultRouter, 200);
+        $this->router->add($chainedRouter, 100);
+
+        $result = $this->router->generate($name, $parameters);
+        $this->assertEquals($name, $result);
+    }
+
+    public function testGenerateNonDefaultStringName()
+    {
+        $name = '/test/this';
+        $parameters = array('test' => 'value');
+
+        $defaultRouter = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
+        $chainedRouter = $this->getMock('Symfony\\Cmf\\Component\\Routing\\ChainedRouterInterface');
+
+        $defaultRouter
+            ->expects($this->never())
+            ->method('generate')
+        ;
+        $chainedRouter
+            ->expects($this->once())
+            ->method('supports')
+            ->will($this->returnValue(true))
+        ;
+        $chainedRouter
+            ->expects($this->once())
+            ->method('generate')
+            ->with($name, $parameters, false)
+            ->will($this->returnValue($name))
+        ;
+
+        $this->router->add($defaultRouter, 200);
+        $this->router->add($chainedRouter, 100);
+
+        $result = $this->router->generate($name, $parameters);
+        $this->assertEquals($name, $result);
+    }
+
     public function testWarmup()
     {
         $dir = 'test_dir';


### PR DESCRIPTION
Bug fix: yes, fixes symfony-cmf/RoutingExtraBundle#19
Backwards compatibility break: No
