### PR TITLE
add an interface for the generator to know if it has the supports method

### DIFF
--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -135,7 +135,7 @@ class ChainRouter implements RouterInterface, RequestMatcherInterface, WarmableI
     {
         $methodNotAllowed = null;
 
-        /** @var $router ChainedRouterInterface */
+        /** @var $router RouterInterface */
         foreach ($this->all() as $router) {
             try {
                 return $router->match($url);
@@ -196,13 +196,13 @@ class ChainRouter implements RouterInterface, RequestMatcherInterface, WarmableI
      */
     public function generate($name, $parameters = array(), $absolute = false)
     {
-        /** @var $router ChainedRouterInterface */
+        /** @var $router RouterInterface */
         foreach ($this->all() as $router) {
 
             // if $name and $router does not implement ChainedRouterInterface and $name is not a string, continue
             // if $name and $router does not implement ChainedRouterInterface and $name is string but does not match a default Symfony2 route name, continue
             if ($name && !$router instanceof ChainedRouterInterface) {
-                if (!is_string($name) || !preg_match('/^[a-z0-9A-Z_.]+$/', $name)) {
+                if (!is_string($name) || !preg_match(VersatileGeneratorInterface::CORE_NAME_PATTERN, $name)) {
                     continue;
                 }
             }

--- a/ChainedRouterInterface.php
+++ b/ChainedRouterInterface.php
@@ -5,21 +5,9 @@ namespace Symfony\Cmf\Component\Routing;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
- * Use this interface on custom routers that can handle non-string route
- * "names".
+ * Interface to combine the VersatileGeneratorInterface with the RouterInterface
  */
-interface ChainedRouterInterface extends RouterInterface
+interface ChainedRouterInterface extends RouterInterface, VersatileGeneratorInterface
 {
-    /**
-     * Whether the router supports the thing in $name to generate a route.
-     *
-     * This check does not need to look if the specific instance can be
-     * resolved to a route, only whether the router can generate routes from
-     * objects of this class.
-
-     * @param mixed $name The route name or route object
-     *
-     * @return bool
-     */
-    public function supports($name);
+    // nothing new to add
 }

--- a/DynamicRouter.php
+++ b/DynamicRouter.php
@@ -18,7 +18,7 @@ use Symfony\Cmf\Component\Routing\Enhancer\RouteEnhancerInterface;
  * A flexible router accepting matcher and generator through injection and
  * using the RouteEnhancer concept to generate additional data on the routes.
  *
- * @author Crell
+ * @author Larry Garfield
  * @author David Buchmann
  */
 class DynamicRouter implements RouterInterface, RequestMatcherInterface, ChainedRouterInterface
@@ -130,14 +130,18 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
     }
 
     /**
-     * Support any string as route name
+     * Delegate to our generator
      *
      * {@inheritDoc}
      */
     public function supports($name)
     {
-        // TODO: check $this->generator instanceof VersatileGeneratorInterface
-        return $this->generator->supports($name);
+        if ($this->generator instanceof VersatileGeneratorInterface) {
+
+            return $this->generator->supports($name);
+        }
+
+        return (!is_string($name) || !preg_match(VersatileGeneratorInterface::CORE_NAME_PATTERN, $name));
     }
 
     /**

--- a/ProviderBasedGenerator.php
+++ b/ProviderBasedGenerator.php
@@ -16,7 +16,7 @@ use Symfony\Cmf\Component\Routing\RouteProviderInterface;
  *
  * @author Larry Garfield
  */
-class ProviderBasedGenerator extends UrlGenerator
+class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorInterface
 {
     /**
      * The route provider for this generator.

--- a/Tests/Routing/DynamicRouterTest.php
+++ b/Tests/Routing/DynamicRouterTest.php
@@ -29,7 +29,7 @@ class DynamicRouterTest extends CmfUnitTestCase
         $this->routeDocument = $this->buildMock('Symfony\\Cmf\\Component\\Routing\\Tests\\Routing\\RouteMock', array('getDefaults'));
 
         $this->matcher = $this->buildMock('Symfony\\Component\\Routing\\Matcher\\UrlMatcherInterface');
-        $this->generator = $this->buildMock('Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface', array('supports', 'generate', 'setContext', 'getContext'));
+        $this->generator = $this->buildMock('Symfony\\Cmf\\Component\\Routing\\VersatileGeneratorInterface', array('supports', 'generate', 'setContext', 'getContext'));
         $this->enhancer = $this->buildMock('Symfony\\Cmf\\Component\\Routing\\Enhancer\\RouteEnhancerInterface', array('enhance'));
 
         $this->context = $this->buildMock('Symfony\\Component\\Routing\\RequestContext');

--- a/VersatileGeneratorInterface.php
+++ b/VersatileGeneratorInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Cmf\Component\Routing;
+
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * This generator is able to handle more than string route names as symfony
+ * core supports them.
+ */
+interface VersatileGeneratorInterface extends UrlGeneratorInterface
+{
+    /**
+     * If $name preg_match this pattern, the name is valid for symfony core
+     * compatible generators.
+     */
+    const CORE_NAME_PATTERN = '/^[a-z0-9A-Z_.]+$/';
+
+    /**
+     * Whether this generator supports the supplied $name.
+     *
+     * This check does not need to look if the specific instance can be
+     * resolved to a route, only whether the router can generate routes from
+     * objects of this class.
+     *
+     * @param mixed $name The route "name" which may also be an object or anything
+     *
+     * @return bool
+     */
+    public function supports($name);
+}
+


### PR DESCRIPTION
/cc @Crell  - i found another missing cleanup that i now fixed. this should not bring a new BC break you if you use / extend ProviderBasedGenerator and not your own generator.

btw i notice that the symfony core routing component puts everything generator into its own subnamespace Generator. i guess we don't want to move them all anymore for the cmf?
