### PR TITLE
Fix values of ROUTE_NAME and ROUTE_OBJECT to what they used to be before d0b651

### DIFF
--- a/RouteObjectInterface.php
+++ b/RouteObjectInterface.php
@@ -19,12 +19,12 @@ interface RouteObjectInterface
     /**
      * Field name that will hold the route name that was matched.
      */
-    const ROUTE_NAME = '_route';
+    const ROUTE_NAME = '_route_name';
 
     /**
      * Field name of the route object that was matched.
      */
-    const ROUTE_OBJECT = '_route_object';
+    const ROUTE_OBJECT = '_route';
 
     /**
      * Constant for the field that is given to the ControllerAliasMapper.


### PR DESCRIPTION
https://github.com/symfony-cmf/Routing/commit/d0b651467366446dba8011c172184bdabd9a6d96 introduced the constants ROUTE_NAME and ROUTE_OBJECT in RouteObjectInterface.php, but as exemplified in the <a href="https://github.com/symfony-cmf/Routing/commit/d0b651467366446dba8011c172184bdabd9a6d96#diff-1">UrlMatcher.php diff</a>, the constants values don't match what the values were before.

This issue was found in http://drupal.org/node/1894002 and is causing some of our tests to fail.
