### PR TITLE
Unset locale if not needed

### DIFF
--- a/ContentAwareGenerator.php
+++ b/ContentAwareGenerator.php
@@ -61,6 +61,8 @@ class ContentAwareGenerator extends ProviderBasedGenerator
             throw new RouteNotFoundException('Route of this document is not an instance of Symfony\Component\Routing\Route but: '.$hint);
         }
 
+        $this->unsetLocaleIfNotNeeded($route, $parameters);
+
         return parent::generate($route, $parameters, $absolute);
     }
 
@@ -248,5 +250,24 @@ class ContentAwareGenerator extends ProviderBasedGenerator
         }
 
         return parent::getRouteDebugMessage($name, $parameters);
+    }
+
+    /**
+     * Unset the _locale parameter if it is there and not needed
+     *
+     * @param SymfonyRoute $route
+     * @param array $parameters
+     */
+    protected  function unsetLocaleIfNotNeeded(SymfonyRoute $route, array &$parameters)
+    {
+        $locale = $this->getLocale($parameters);
+        if (null !== $locale) {
+            if (preg_match('/'.$route->getRequirement('_locale').'/', $locale) && $locale == $route->getDefault('_locale')) {
+                $compiledRoute = $route->compile();
+                if (!in_array('_locale', $compiledRoute->getVariables())) {
+                    unset($parameters['_locale']);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Second attempt at removing the _locale parameter so that it is not appended to the query string. 

This works in my case (same routes setup as the sandbox) but hasn't been tested for the SE.

I'm also open to a solution similar to the one the SimpleCmsBundle uses but haven't tried that yet since it seems rather complicated to me setting up the routes tree for that if you want different urls for different locales.  
