### PR TITLE
Added optional RegisterRoutersPass

### DIFF
--- a/DependencyInjection/RegisterRoutersPass.php
+++ b/DependencyInjection/RegisterRoutersPass.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Symfony\Cmf\Component\Routing\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Compiler pass to register routers to the ChainRouter.
+ *
+ * @author Wouter J <waldio.webdesign@gmail.com>
+ * @author Henrik Bjornskov <henrik@bjrnskov.dk>
+ * @author Magnus Nordlander <magnus@e-butik.se>
+ */
+class RegisterRoutersPass implements CompilerPassInterface
+{
+    /**
+     * @var string
+     */
+    protected $chainRouterService;
+
+    protected $routerTag;
+
+    public function __construct($chainRouterService = 'cmf_routing.router', $routerTag = 'router')
+    {
+        $this->chainRouterService = $chainRouterService;
+        $this->routerTag = $routerTag;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition($this->chainRouterService)) {
+            return;
+        }
+
+        $definition = $container->getDefinition($this->chainRouterService);
+
+        foreach ($container->findTaggedServiceIds($this->routerTag) as $id => $attributes) {
+            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
+
+            $definition->addMethodCall('add', array(new Reference($id), $priority));
+        }
+    }
+}

--- a/Tests/DependencyInjection/RegisterRoutersPassTest.php
+++ b/Tests/DependencyInjection/RegisterRoutersPassTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Symfony\Cmf\Routing\Tests\DependencyInjection;
+
+use Symfony\Cmf\Component\Routing\DependencyInjection\RegisterRoutersPass;
+
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterRoutersPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getValidRoutersData
+     */
+    public function testValidRouters($name, $priority = null)
+    {
+        $services = array();
+        $services[$name] = array(0 => array('priority' => $priority));
+
+        $priority = $priority ?: 0;
+
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $definition->expects($this->atLeastOnce())
+            ->method('addMethodCall')
+            ->with($this->equalTo('add'), $this->callback(function($arg) use ($name, $priority) {
+                if (!$arg[0] instanceof Reference || $name !== $arg[0]->__toString()) {
+                    return false;
+                }
+
+                if ($priority !== $arg[1]) {
+                    return false;
+                }
+
+                return true;
+            }));
+
+        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder', array('hasDefinition', 'findTaggedServiceIds', 'getDefinition'));
+        $builder->expects($this->any())
+            ->method('hasDefinition')
+            ->will($this->returnValue(true));
+
+        $builder->expects($this->atLeastOnce())
+            ->method('findTaggedServiceIds')
+            ->will($this->returnValue($services));
+
+        $builder->expects($this->atLeastOnce())
+            ->method('getDefinition')
+            ->will($this->returnValue($definition));
+
+        $registerRoutersPass = new RegisterRoutersPass();
+        $registerRoutersPass->process($builder);
+    }
+
+    public function getValidRoutersData()
+    {
+        return array(
+            array('my_router'),
+            array('my_primary_router', 99),
+            array('my_router', 0),
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "symfony/http-kernel": "~2.2",
         "psr/log": "~1.0"
     },
+    "require-dev": {
+        "symfony/dependency-injection": "~2.0"
+    },
     "suggest": {
         "symfony/http-foundation": "ChainRouter/DynamicRouter have optional support for Request instances, several enhancers require a Request instances, ~2.2"
     },


### PR DESCRIPTION
I had created this pass for my cms and I thought it's maybe a good idea to include it in the component. This way, it's easily reusable and it doesn't add dependencies to the component, just use it when you would like to use it. This is also done in the core framework with for instance the RegisterListenersPass for the EventDispatcher component.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
