### PR TITLE
use request context to determine locale

### DIFF
--- a/ContentAwareGenerator.php
+++ b/ContentAwareGenerator.php
@@ -17,6 +17,14 @@ use Symfony\Component\Routing\RouteCollection;
 class ContentAwareGenerator extends ProviderBasedGenerator
 {
     /**
+     * The locale to use when neither the parameters nor the request context
+     * indicate the locale to use.
+     *
+     * @var string
+     */
+    protected $defaultLocale = null;
+
+    /**
      * The content repository used to find content by it's id
      * This can be used to specify a parameter content_id when generating urls
      *
@@ -218,8 +226,9 @@ class ContentAwareGenerator extends ProviderBasedGenerator
      *
      * @param array $parameters the parameters determined by the route
      *
-     * @return string|null the locale following of the parameters or any other
-     *  information the router has available.
+     * @return string the locale following of the parameters or any other
+     *  information the router has available. defaultLocale if no other locale
+     *  can be determined.
      */
     protected function getLocale($parameters)
     {
@@ -227,7 +236,22 @@ class ContentAwareGenerator extends ProviderBasedGenerator
             return $parameters['_locale'];
         }
 
-        return null;
+        if ($this->getContext()->hasParameter('_locale')) {
+            return $this->getContext()->getParameter('_locale');
+        }
+
+        return $this->defaultLocale;
+    }
+
+    /**
+     * Overwrite the locale to be used by default if there is neither one in
+     * the parameters when building the route nor a request available (i.e. CLI).
+     *
+     * @param string $locale
+     */
+    public function setDefaultLocale($locale)
+    {
+        $this->defaultLocale = $locale;
     }
 
     /**

--- a/ProviderBasedGenerator.php
+++ b/ProviderBasedGenerator.php
@@ -2,13 +2,14 @@
 
 namespace Symfony\Cmf\Component\Routing;
 
+use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Route as SymfonyRoute;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
-use Symfony\Component\Routing\Generator\UrlGenerator;
-use Psr\Log\LoggerInterface;
-
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
+
+use Psr\Log\LoggerInterface;
 
 /**
  * A Generator that uses a RouteProvider rather than a RouteCollection
@@ -28,6 +29,7 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
     {
         $this->provider = $provider;
         $this->logger = $logger;
+        $this->context = new RequestContext();
     }
 
     /**

--- a/Tests/Routing/ContentAwareGeneratorTest.php
+++ b/Tests/Routing/ContentAwareGeneratorTest.php
@@ -380,6 +380,32 @@ class ContentAwareGeneratorTest extends CmfUnitTestCase
         $this->generator->generate($this->contentDocument);
     }
 
+    public function testGetLocaleAttribute()
+    {
+        $this->generator->setDefaultLocale('en');
+
+        $attributes = array('_locale' => 'fr');
+        $this->assertEquals('fr', $this->generator->getLocale($attributes));
+    }
+
+    public function testGetLocaleDefault()
+    {
+        $this->generator->setDefaultLocale('en');
+
+        $attributes = array();
+        $this->assertEquals('en', $this->generator->getLocale($attributes));
+    }
+
+    public function testGetLocaleContext()
+    {
+        $this->generator->setDefaultLocale('en');
+
+        $this->generator->getContext()->setParameter('_locale', 'de');
+
+        $attributes = array();
+        $this->assertEquals('de', $this->generator->getLocale($attributes));
+    }
+
     public function testSupports()
     {
         $this->assertTrue($this->generator->supports(''));
@@ -404,6 +430,12 @@ class TestableContentAwareGenerator extends ContentAwareGenerator
     protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $absolute, $hostTokens = null)
     {
         return 'result_url';
+    }
+
+    // expose as public
+    public function getLocale($parameters)
+    {
+        return parent::getLocale($parameters);
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony-cmf/RoutingBundle/issues/34 |
| License | MIT |

we should look at the request context to determine the locale. are there any unexpected side effects of this? tests and the cmf sandbox are happy with this. /cc @Crell 
