### PR TITLE
with doctrine, the routes are probably a Collection. reset() on a collection does not work

### DIFF
--- a/ContentAwareGenerator.php
+++ b/ContentAwareGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Cmf\Component\Routing;
 
+use Doctrine\Common\Collections\Collection;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\RouteCollection;
@@ -181,7 +182,11 @@ class ContentAwareGenerator extends ProviderBasedGenerator
             return $route;
         }
 
-        // if none matched, continue and randomly return the first one
+        // if none matched, randomly return the first one
+        if ($routes instanceof Collection) {
+            return $routes->first();
+        }
+
         return reset($routes);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | see travis |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
