### PR TITLE
remove source from the FieldPresenceEnhancer

### DIFF
--- a/Enhancer/FieldPresenceEnhancer.php
+++ b/Enhancer/FieldPresenceEnhancer.php
@@ -37,7 +37,7 @@ class FieldPresenceEnhancer implements RouteEnhancerInterface
     private $value;
 
     /**
-     * @param string $source the field name of the class
+     * @param null|string $source the field name of the class, null to disable the check
      * @param string $target the field name to set from the map
      * @param string $value  value to set target field to if source field exists
      */
@@ -58,7 +58,7 @@ class FieldPresenceEnhancer implements RouteEnhancerInterface
             return $defaults;
         }
 
-        if (! isset($defaults[$this->source])) {
+        if (null !== $this->source && !isset($defaults[$this->source])) {
             return $defaults;
         }
 

--- a/Tests/Enhancer/FieldPresenceEnhancerTest.php
+++ b/Tests/Enhancer/FieldPresenceEnhancerTest.php
@@ -52,9 +52,21 @@ class FieldPresenceEnhancerTest extends CmfUnitTestCase
         $this->assertEquals($defaults, $this->mapper->enhance($defaults, $this->request));
     }
 
-    public function testHasNoTemplate()
+    public function testHasNoSourceValue()
     {
         $defaults = array('foo' => 'bar');
         $this->assertEquals($defaults, $this->mapper->enhance($defaults, $this->request));
+    }
+
+    public function testHasNoSource()
+    {
+        $this->mapper = new FieldPresenceEnhancer(null, '_controller', 'cmf_content.controller:indexAction');
+
+        $defaults = array('foo' => 'bar');
+        $expected = array(
+            'foo' => 'bar',
+            '_controller' => 'cmf_content.controller:indexAction',
+        );
+        $this->assertEquals($expected, $this->mapper->enhance($defaults, $this->request));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I am not sure when its really useful to also check if a `source` field is also present. To me this enhancer is about setting a default for a given field. Why would I only want to set a default for `_controller` if `_template` is set and `_controller` is not set?

/cc @dbu
