### PR TITLE
[LazyRouteCollection] Missing argument bug for getRoutesByNames method f...

### DIFF
--- a/LazyRouteCollection.php
+++ b/LazyRouteCollection.php
@@ -37,7 +37,7 @@ class LazyRouteCollection extends RouteCollection
      */
     public function count()
     {
-        return count($this->all());
+        return count($this->all(null));
     }
 
     /**


### PR DESCRIPTION
...ixed

I have noticed that [LazyRouteCollection.php#L50](https://github.com/symfony-cmf/Routing/blob/master/LazyRouteCollection.php#L50) is calling `getRoutesByNames` method on [RouteProviderInterface](https://github.com/symfony-cmf/Routing/blob/master/RouteProviderInterface.php) without any arguments. 

As method expects at least a name arg, php throws a missing argument error.

According to RouteProviderInterface:

> If $names is null, this method SHOULD return a collection of all routes
> known to this provider.
