### PR TITLE
add a post match event

### DIFF
--- a/DynamicRouter.php
+++ b/DynamicRouter.php
@@ -12,6 +12,7 @@
 
 namespace Symfony\Cmf\Component\Routing;
 
+use Symfony\Cmf\Component\Routing\Event\RouterPostMatchEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
@@ -220,6 +221,11 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
 
         $defaults = $matcher->match($pathinfo);
 
+        if ($this->eventDispatcher) {
+            $event = new RouterPostMatchEvent($defaults);
+            $this->eventDispatcher->dispatch(Events::POST_DYNAMIC_MATCH, $event);
+        }
+
         return $this->applyRouteEnhancers($defaults, $request);
     }
 
@@ -256,6 +262,11 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
             $defaults = $matcher->match($request->getPathInfo());
         } else {
             $defaults = $matcher->matchRequest($request);
+        }
+
+        if ($this->eventDispatcher) {
+            $event = new RouterPostMatchEvent($defaults, $request);
+            $this->eventDispatcher->dispatch(Events::POST_DYNAMIC_MATCH_REQUEST, $event);
         }
 
         return $this->applyRouteEnhancers($defaults, $request);

--- a/Event/Events.php
+++ b/Event/Events.php
@@ -22,9 +22,23 @@ final class Events
     const PRE_DYNAMIC_MATCH = 'cmf_routing.pre_dynamic_match';
 
     /**
-     * Fired before a Request is matched in \Symfony\Cmf\Component\Routing\DynamicRouter#match
+     * Fired after a path is final matched in \Symfony\Cmf\Component\Routing\DynamicRouter#match
+     *
+     * The event object is RoutePostMatchEvent.
+     */
+    const POST_DYNAMIC_MATCH = 'cmf_routing.post_dynamic_match';
+
+    /**
+     * Fired before a Request is matched in \Symfony\Cmf\Component\Routing\DynamicRouter#matchRequest
      *
      * The event object is RouteMatchEvent.
      */
     const PRE_DYNAMIC_MATCH_REQUEST = 'cmf_routing.pre_dynamic_match_request';
+
+    /**
+     * Fired after a Request is final matched in \Symfony\Cmf\Component\Routing\DynamicRouter#matchRequest
+     *
+     * The event object is RoutePostMatchEvent.
+     */
+    const POST_DYNAMIC_MATCH_REQUEST = 'cmf_routing.post_dynamic_match_request';
 }

--- a/Event/RouterPostMatchEvent.php
+++ b/Event/RouterPostMatchEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Component\Routing\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class RouterPostMatchEvent extends RouterMatchEvent
+{
+    /**
+     * @var array
+     */
+    protected $defaults;
+
+    /**
+     * @param array $defaults
+     * @param Request $request
+     */
+    public function __construct(array $defaults, Request $request = null)
+    {
+        parent::__construct($request);
+        $this->defaults = $defaults;
+    }
+
+    /**
+     * @return array
+     */
+    public function &getDefaults() {
+        return $this->defaults;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | TODO |

Drupal would like to change the request based upon the route information directly after final matching the route.

Therefore this pull request adds POST_DYNAMIC_MATCH/POST_DYNAMIC_MATCH_REQUEST to have a good counterpart for the PRE events.

Reference the original drupal issue https://drupal.org/node/2026431
