### PR TITLE
remove deprecated parameter $parameters

### DIFF
--- a/ContentAwareGenerator.php
+++ b/ContentAwareGenerator.php
@@ -97,7 +97,7 @@ class ContentAwareGenerator extends ProviderBasedGenerator
      */
     protected function getRouteByName($name, array $parameters)
     {
-        $route = $this->provider->getRouteByName($name, $parameters);
+        $route = $this->provider->getRouteByName($name);
         if (empty($route)) {
             throw new RouteNotFoundException('No route found for name: ' . $name);
         }

--- a/RouteProviderInterface.php
+++ b/RouteProviderInterface.php
@@ -51,15 +51,13 @@ interface RouteProviderInterface
      * Find the route using the provided route name.
      *
      * @param string $name       the route name to fetch
-     * @param array  $parameters DEPRECATED the parameters as they are passed
-     *      to the UrlGeneratorInterface::generate call
      *
      * @return \Symfony\Component\Routing\Route
      *
      * @throws \Symfony\Component\Routing\Exception\RouteNotFoundException if
      *      there is no route with that name in this repository
      */
-    public function getRouteByName($name, $parameters = array());
+    public function getRouteByName($name);
 
     /**
      * Find many routes by their names using the provided list of names.


### PR DESCRIPTION
$parameters got marked as deprecated in the last release, i guess this allows us to remove it in this release.
