### PR TITLE
drop Symfony 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
     - 5.5
 
 env:
-  - SYMFONY_VERSION=2.2.*
   - SYMFONY_VERSION=2.3.*
   - SYMFONY_VERSION=2.4.*
   - SYMFONY_VERSION=dev-master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.2.0-RC2
+---------
+
+* **2014-04-11**: drop Symfony 2.2 compatibility
+
 1.2.0-RC1
 ---------
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and licensed under the [MIT License](LICENSE).
 
 ## Requirements
 
-* The Symfony Routing component (>= 2.2.0)
+* The Symfony Routing component (2.3+)
 * See also the `require` section of [composer.json](composer.json)
 
 

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "symfony/routing": "~2.2",
-        "symfony/http-kernel": "~2.2",
+        "symfony/routing": "~2.3",
+        "symfony/http-kernel": "~2.3",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes (bumped dependency) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Not sure if we should bump these requirements or only for Bundles that dependent on the FrameworkBundle
