### PR TITLE
Pass parameters through to Route Provider

### DIFF
--- a/ContentAwareGenerator.php
+++ b/ContentAwareGenerator.php
@@ -97,7 +97,7 @@ class ContentAwareGenerator extends ProviderBasedGenerator
      */
     protected function getRouteByName($name, array $parameters)
     {
-        $route = $this->provider->getRouteByName($name);
+        $route = $this->provider->getRouteByName($name, $parameters);
         if (empty($route)) {
             throw new RouteNotFoundException('No route found for name: ' . $name);
         }


### PR DESCRIPTION
Pass the route parameters given to the generator through to the RouteProvider's getRouteByName method so parameters can be used when generating.
