### PR TITLE
Force absolute url generation depending on route host

### DIFF
--- a/ProviderBasedGenerator.php
+++ b/ProviderBasedGenerator.php
@@ -60,6 +60,10 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
 
         $debug_message = $this->getRouteDebugMessage($name);
 
+        if ($route->getHost() && $route->getHost() !== $this->context->getHost()) {
+            $absolute = true;
+        }
+
         return $this->doGenerate($compiledRoute->getVariables(), $route->getDefaults(), $route->getRequirements(), $compiledRoute->getTokens(), $parameters, $debug_message, $absolute, $hostTokens);
     }
 

--- a/Tests/Routing/ProviderBasedGeneratorTest.php
+++ b/Tests/Routing/ProviderBasedGeneratorTest.php
@@ -122,6 +122,33 @@ class ProviderBasedGeneratorTest extends CmfUnitTestCase
         $this->assertSame(null, $this->generator->generate($route, array('number' => 'string')));
 
     }
+
+    public function hostDataProvider()
+    {
+        return array(
+            array(null, null, '/test'),
+            array('www.example.com', null, '/test'),
+            array('www.example.com', 'www.example.com', '/test'),
+            array('www.example.com', 'fr.example.com', 'http://fr.example.com/test'),
+        );
+    }
+
+    /**
+     * @dataProvider hostDataProvider
+     */
+    public function testGenerateAbsoluteRouteIfHostIsDifferent($contextHost, $routeHost, $expectedUrl)
+    {
+        $this->generator = new ProviderBasedGenerator($this->provider);
+
+        $route = new Route('/test');
+        $route->setHost($routeHost);
+
+        $context = new RequestContext();
+        $context->setHost($contextHost);
+        $this->generator->setContext($context);
+
+        $this->assertSame($expectedUrl, $this->generator->generate($route));
+    }
 }
 
 /**


### PR DESCRIPTION
Hi,

I my [MultiDomainBundle](https://github.com/M4nu/MultiDomainBundle) I need to generate absolute url if the route host is different from the context host.

Is it possible to include this feature in this library ?
