### PR TITLE
Add RouterGenerateEvent to provide option to manipulate routes

### DIFF
--- a/DynamicRouter.php
+++ b/DynamicRouter.php
@@ -155,9 +155,9 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
      * If the generator is not able to generate the url, it must throw the
      * RouteNotFoundException as documented below.
      *
-     * @param string  $name       The name of the route
-     * @param mixed   $parameters An array of parameters
-     * @param Boolean $absolute   Whether to generate an absolute URL
+     * @param string|Symfony\Component\Routing\Route $name       The name of the route or the Route instance
+     * @param mixed                                  $parameters An array of parameters
+     * @param Boolean                                $absolute   Whether to generate an absolute URL
      *
      * @return string The generated URL
      *

--- a/DynamicRouter.php
+++ b/DynamicRouter.php
@@ -26,6 +26,7 @@ use Symfony\Cmf\Component\Routing\Enhancer\RouteEnhancerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Cmf\Component\Routing\Event\Events;
 use Symfony\Cmf\Component\Routing\Event\RouterMatchEvent;
+use Symfony\Cmf\Component\Routing\Event\RouterGenerateEvent;
 
 /**
  * A flexible router accepting matcher and generator through injection and
@@ -166,6 +167,14 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
      */
     public function generate($name, $parameters = array(), $absolute = false)
     {
+        if ($this->eventDispatcher) {
+            $event = new RouterGenerateEvent($name, $parameters, $absolute);
+            $this->eventDispatcher->dispatch(Events::PRE_DYNAMIC_GENERATE, $event);
+            $name = $event->getName();
+            $parameters = $event->getParameters();
+            $absolute = $event->isAbsolute();
+        }
+
         return $this->getGenerator()->generate($name, $parameters, $absolute);
     }
 

--- a/Event/Events.php
+++ b/Event/Events.php
@@ -16,21 +16,21 @@ final class Events
     /**
      * Fired before a path is matched in \Symfony\Cmf\Component\Routing\DynamicRouter#match
      *
-     * The event object is RouteMatchEvent.
+     * The event object is RouterMatchEvent.
      */
     const PRE_DYNAMIC_MATCH = 'cmf_routing.pre_dynamic_match';
 
     /**
      * Fired before a Request is matched in \Symfony\Cmf\Component\Routing\DynamicRouter#match
      *
-     * The event object is RouteMatchEvent.
+     * The event object is RouterMatchEvent.
      */
     const PRE_DYNAMIC_MATCH_REQUEST = 'cmf_routing.pre_dynamic_match_request';
 
     /**
      * Fired before a route is generated in \Symfony\Cmf\Component\Routing\DynamicRouter#generate
      *
-     * The event object is RouteGenerateEvent.
+     * The event object is RouterGenerateEvent.
      */
     const PRE_DYNAMIC_GENERATE = 'cmf_routing.pre_dynamic_generate';
 }

--- a/Event/Events.php
+++ b/Event/Events.php
@@ -26,4 +26,11 @@ final class Events
      * The event object is RouteMatchEvent.
      */
     const PRE_DYNAMIC_MATCH_REQUEST = 'cmf_routing.pre_dynamic_match_request';
+
+    /**
+     * Fired before a route is generated in \Symfony\Cmf\Component\Routing\DynamicRouter#generate
+     *
+     * The event object is RouteGenerateEvent.
+     */
+    const PRE_DYNAMIC_GENERATE = 'cmf_routing.pre_dynamic_generate';
 }

--- a/Event/RouterGenerateEvent.php
+++ b/Event/RouterGenerateEvent.php
@@ -23,17 +23,17 @@ class RouterGenerateEvent extends Event
     /**
      * @var string
      */
-    protected $name;
+    private $name;
 
     /**
      * @var array
      */
-    protected $parameters;
+    private $parameters;
 
     /**
      * @var bool
      */
-    protected $absolute;
+    private $absolute;
 
     /**
      * @param string $name 

--- a/Event/RouterGenerateEvent.php
+++ b/Event/RouterGenerateEvent.php
@@ -21,17 +21,23 @@ use Symfony\Component\EventDispatcher\Event;
 class RouterGenerateEvent extends Event
 {
     /**
+     * The route name to generate a url for
+     * 
      * @var string
      */
     private $name;
 
     /**
+     * The parameters to use when generating the url
+     * 
      * @var array
      */
     private $parameters;
 
     /**
-     * @var bool
+     * Whether the generated url should be absolute
+     * 
+     * @var array
      */
     private $absolute;
 
@@ -48,6 +54,8 @@ class RouterGenerateEvent extends Event
     }
 
     /**
+     * Get route name
+     * 
      * @return string
      */
     public function getName()
@@ -56,6 +64,8 @@ class RouterGenerateEvent extends Event
     }
 
     /**
+     * Set route name
+     * 
      * @param string $name 
      */
     public function setName($name)
@@ -64,6 +74,8 @@ class RouterGenerateEvent extends Event
     }
 
     /**
+     * Get route parameters
+     * 
      * @return array
      */
     public function getParameters()
@@ -72,6 +84,8 @@ class RouterGenerateEvent extends Event
     }
 
     /**
+     * Set the route parameters
+     *
      * @param array $parameters 
      */
     public function setParameters(array $parameters)
@@ -80,6 +94,29 @@ class RouterGenerateEvent extends Event
     }
 
     /**
+     * Set a route parameter
+     * 
+     * @param mixed $key 
+     * @param mixed $value 
+     */
+    public function setParameter($key, $value)
+    {
+        $this->parameters[$key] = $value;
+    }
+
+    /**
+     * Remove a route parameter by key
+     * 
+     * @param mixed $key 
+     */
+    public function removeParameter($key)
+    {
+        unset($this->parameters[$key]);
+    }
+
+    /**
+     * Should the generated url be absolute
+     * 
      * @return bool
      */
     public function isAbsolute()
@@ -88,7 +125,9 @@ class RouterGenerateEvent extends Event
     }
 
     /**
-     * @param bool $absolute
+     * Set whether the generated url should be absolute
+     * 
+     * @param bool $absolute 
      */
     public function setAbsolute($absolute)
     {

--- a/Event/RouterGenerateEvent.php
+++ b/Event/RouterGenerateEvent.php
@@ -16,6 +16,8 @@ use Symfony\Component\EventDispatcher\Event;
 /**
  * Event fired before the dynamic router generates a url for a route
  * The name, parameters and absolute properties are used by the url generator
+ *
+ * @author Ben Glassman
  * @see Symfony\Component\Routing\Generator\UrlGeneratorInterface::generate()
  */
 class RouterGenerateEvent extends Event

--- a/Event/RouterGenerateEvent.php
+++ b/Event/RouterGenerateEvent.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\Routing\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class RouterGenerateEvent extends Event
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * @var bool
+     */
+    protected $absolute;
+
+    /**
+     * @param Request $request
+     */
+    public function __construct($name, $parameters, $absolute)
+    {
+        $this->name = $name;
+        $this->parameters = $parameters;
+        $this->absolute = $absolute;
+    }
+
+    /**
+     * @return array
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name 
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param array $parameters 
+     */
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAbsolute()
+    {
+        return $this->absolute;
+    }
+
+    /**
+     * @param bool $absolute
+     */
+    public function setAbsolute($absolute)
+    {
+        $this->absolute = $absolute;
+    }
+}

--- a/Event/RouterGenerateEvent.php
+++ b/Event/RouterGenerateEvent.php
@@ -21,8 +21,7 @@ use Symfony\Component\EventDispatcher\Event;
 class RouterGenerateEvent extends Event
 {
     /**
-     * The route to generate a url for
-     * This could be a route name or an instance of Symfony's Route class
+     * The name of the route or the Route instance
      * 
      * @var string|Symfony\Component\Routing\Route
      */
@@ -43,7 +42,7 @@ class RouterGenerateEvent extends Event
     private $absolute;
 
     /**
-     * @param string $name 
+     * @param string|Symfony\Component\Routing\Route $name 
      * @param array $parameters 
      * @param bool $absolute 
      */
@@ -57,7 +56,7 @@ class RouterGenerateEvent extends Event
     /**
      * Get route name
      * 
-     * @return string
+     * @return string|Symfony\Component\Routing\Route
      */
     public function getName()
     {
@@ -67,7 +66,7 @@ class RouterGenerateEvent extends Event
     /**
      * Set route name
      * 
-     * @param string $name 
+     * @param string|Symfony\Component\Routing\Route $name 
      */
     public function setName($name)
     {

--- a/Event/RouterGenerateEvent.php
+++ b/Event/RouterGenerateEvent.php
@@ -13,6 +13,11 @@ namespace Symfony\Cmf\Component\Routing\Event;
 
 use Symfony\Component\EventDispatcher\Event;
 
+/**
+ * Event fired before the dynamic router generates a url for a route
+ * The name, parameters and absolute properties are used by the url generator
+ * @see Symfony\Component\Routing\Generator\UrlGeneratorInterface::generate()
+ */
 class RouterGenerateEvent extends Event
 {
     /**
@@ -43,7 +48,7 @@ class RouterGenerateEvent extends Event
     }
 
     /**
-     * @return array
+     * @return string
      */
     public function getName()
     {

--- a/Event/RouterGenerateEvent.php
+++ b/Event/RouterGenerateEvent.php
@@ -31,7 +31,9 @@ class RouterGenerateEvent extends Event
     protected $absolute;
 
     /**
-     * @param Request $request
+     * @param string $name 
+     * @param array $parameters 
+     * @param bool $absolute 
      */
     public function __construct($name, $parameters, $absolute)
     {

--- a/Event/RouterGenerateEvent.php
+++ b/Event/RouterGenerateEvent.php
@@ -21,9 +21,10 @@ use Symfony\Component\EventDispatcher\Event;
 class RouterGenerateEvent extends Event
 {
     /**
-     * The route name to generate a url for
+     * The route to generate a url for
+     * This could be a route name or an instance of Symfony's Route class
      * 
-     * @var string
+     * @var string|Symfony\Component\Routing\Route
      */
     private $name;
 

--- a/Event/RouterGenerateEvent.php
+++ b/Event/RouterGenerateEvent.php
@@ -96,7 +96,7 @@ class RouterGenerateEvent extends Event
     /**
      * Set a route parameter
      * 
-     * @param mixed $key 
+     * @param string $key 
      * @param mixed $value 
      */
     public function setParameter($key, $value)
@@ -107,7 +107,7 @@ class RouterGenerateEvent extends Event
     /**
      * Remove a route parameter by key
      * 
-     * @param mixed $key 
+     * @param string $key 
      */
     public function removeParameter($key)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ???
| License       | MIT
| Doc PR        | https://github.com/symfony-cmf/symfony-cmf-docs/pull/672

DynamicRouter dispatches RouterMatch and RouterMatchRequest events when match and matchRequest are called but does not dispatch an event when generate is called.

The specific use case that we might use something like this for in our application is supporting using some kind of special syntax for loading PHPCR pages based on a unique immutable non-client editable slug field. For example a page with a slug field value of 'privacy-policy' that is not editable by clients. We would be able to do something like this in twig

```twig
{{ path('@privacy-policy') }}
``` 

And instead of having to define a custom router router chain we could simply respond to this pre-generate event to change the route name from '@privacy-policy' to the real uuid or path to the PHPCR document.

I know there is already some work in the resource bundles by @dantleech regarding having different ways to load documents based on something other than phpcr id or uuid. It feels like if there are match/match request events that a generate event makes sense and there are probably other uses I am not thinking of.

This relates to https://github.com/symfony-cmf/RoutingBundle/issues/178 in a broad sense since it adds an extension point that might be usable for this purpose.

@dbu @dantleech thoughts?