### PR TITLE
[2.2] Route#getPattern is renamed to getPath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
       env: SYMFONY_VERSION=3.0.*
   allow_failures:
     - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.6
       env: SYMFONY_VERSION=3.0.*
 
 before_install:

--- a/ProviderBasedGenerator.php
+++ b/ProviderBasedGenerator.php
@@ -91,7 +91,7 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
         }
 
         if ($name instanceof SymfonyRoute) {
-            return 'Route with pattern ' . $name->getPattern();
+            return 'Route with path ' . $name->getPath();
         }
 
         return get_class($name);


### PR DESCRIPTION
As `~2.2` is set as requirement, this can be done without breaking anything.

After this, the Routing component is deprecation free.