### PR TITLE
VersatileGeneratorInterface getRouteDebugMessage() requires an array.

### DIFF
--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -248,10 +248,10 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
         throw new RouteNotFoundException(sprintf('None of the chained routers were able to generate route: %s', $info));
     }
 
-    private function getErrorMessage($name, $router = null, $parameters = null)
+    private function getErrorMessage($name, $router = null, $parameters = array())
     {
         if ($router instanceof VersatileGeneratorInterface) {
-            $displayName = $router->getRouteDebugMessage($name, $parameters);
+            $displayName = $router->getRouteDebugMessage($name, $parameters ?: array());
         } elseif (is_object($name)) {
             $displayName = method_exists($name, '__toString')
                 ? (string) $name

--- a/Tests/Routing/ChainRouterTest.php
+++ b/Tests/Routing/ChainRouterTest.php
@@ -528,6 +528,37 @@ class ChainRouterTest extends CmfUnitTestCase
     }
 
     /**
+     * The signature of VersatileGeneratorInterface getRouteDebugMessage() requires
+     * that the parameters argument be of type array.
+     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
+     */
+    public function testGenerateWithNullParameters()
+    {
+        $url = '/test';
+        $name = 'test';
+        $parameters = null;
+        $router = $this->getMock('Symfony\Cmf\Component\Routing\Tests\Routing\VersatileRouter');
+
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with($name, $parameters, false)
+            ->will($this->throwException(new RouteNotFoundException()))
+        ;
+        $router
+            ->expects($this->once())
+            ->method('supports')
+            ->with($name)
+            ->will($this->returnValue(true))
+        ;
+
+        $this->router->add($router);
+
+        $result = $this->router->generate($name, $parameters);
+        $this->assertEquals($url, $result);
+    }
+
+    /**
      * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
      */
     public function testGenerateNotFound()


### PR DESCRIPTION
Due to an error in our application, I was seeing 
`PHP message: PHP Catchable fatal error:  Argument 2 passed to Symfony\Cmf\Component\Routing\DynamicRouter::getRouteDebugMessage() must be of the type array, null given, called in /usr/share/nginx/www/sites/sgmarketplace/vendor/symfony-cmf/routing/ChainRouter.php on line 254 and defined in /usr/share/nginx/www/sites/sgmarketplace/vendor/symfony-cmf/routing/DynamicRouter.php on line 365`
but I was unable to diagnose our issue until I got the fatal error out of the way with the attached patch.