### PR TITLE
ChainRouter: matching: can not use Request from Request::create($url)

### DIFF
--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -172,17 +172,12 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
     {
         $methodNotAllowed = null;
 
-        $requestForMatching = $request;
         foreach ($this->all() as $router) {
             try {
                 // the request/url match logic is the same as in Symfony/Component/HttpKernel/EventListener/RouterListener.php
                 // matching requests is more powerful than matching URLs only, so try that first
-                if ($router instanceof RequestMatcherInterface) {
-                    if (empty($requestForMatching)) {
-                        $requestForMatching = Request::create($url);
-                    }
-
-                    return $router->matchRequest($requestForMatching);
+                if (null !== $request && $router instanceof RequestMatcherInterface) {
+                    return $router->matchRequest($request);
                 }
                 // every router implements the match method
                 return $router->match($url);


### PR DESCRIPTION
Url `http://www.example.com//foo/` is matched as `http://www.example.com/`

Cause Request created by
```php
$requestForMatching = Request::create($url);
```
can not be valid for `$url = '//foo/';` because
```php
$requestForMatching->getPathInfo() === '/';
$requestForMatching->getRequestUri() === '/';
```