### PR TITLE
VersatileGeneratorInterface getRouteDebugMessage() requires an array.

### DIFF
--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -230,7 +230,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
             try {
                 return $router->generate($name, $parameters, $absolute);
             } catch (RouteNotFoundException $e) {
-                $hint = $this->getErrorMessage($name, $router, $parameters);
+                $hint = $this->getErrorMessage($name, $router, is_array($parameters) ? $parameters : array());
                 $debug[] = $hint;
                 if ($this->logger) {
                     $this->logger->debug('Router '.get_class($router)." was unable to generate route. Reason: '$hint': ".$e->getMessage());
@@ -248,7 +248,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
         throw new RouteNotFoundException(sprintf('None of the chained routers were able to generate route: %s', $info));
     }
 
-    private function getErrorMessage($name, $router = null, $parameters = null)
+    private function getErrorMessage($name, $router = null, array $parameters = array())
     {
         if ($router instanceof VersatileGeneratorInterface) {
             $displayName = $router->getRouteDebugMessage($name, $parameters);

--- a/Tests/Routing/ChainRouterTest.php
+++ b/Tests/Routing/ChainRouterTest.php
@@ -515,6 +515,36 @@ class ChainRouterTest extends CmfUnitTestCase
     }
 
     /**
+     * The signature of VersatileGeneratorInterface getRouteDebugMessage() requires
+     * that the parameters argument be of type array.
+     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
+     */
+    public function testGenerateWithNullParameters()
+    {
+        $url = '/test';
+        $name = 'test';
+        $router = $this->getMock('Symfony\Cmf\Component\Routing\Tests\Routing\VersatileRouter');
+
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with($name, null, false)
+            ->will($this->throwException(new RouteNotFoundException()))
+        ;
+        $router
+            ->expects($this->once())
+            ->method('supports')
+            ->with($name)
+            ->will($this->returnValue(true))
+        ;
+
+        $this->router->add($router);
+
+        $result = $this->router->generate($name, null);
+        $this->assertEquals($url, $result);
+    }
+
+    /**
      * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
      */
     public function testGenerateNotFound()


### PR DESCRIPTION
fix #146, replace #149

Due to an error in our application, I was seeing 
`PHP message: PHP Catchable fatal error:  Argument 2 passed to Symfony\Cmf\Component\Routing\DynamicRouter::getRouteDebugMessage() must be of the type array, null given, called in /usr/share/nginx/www/sites/sgmarketplace/vendor/symfony-cmf/routing/ChainRouter.php on line 254 and defined in /usr/share/nginx/www/sites/sgmarketplace/vendor/symfony-cmf/routing/DynamicRouter.php on line 365`
but I was unable to diagnose our issue until I got the fatal error out of the way with the attached patch.