### PR TITLE
fix url generator signature using the constant for reference type

### DIFF
--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -211,7 +211,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
      * Loops through all registered routers and returns a router if one is found.
      * It will always return the first route generated.
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
         $debug = array();
 
@@ -228,7 +228,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
             }
 
             try {
-                return $router->generate($name, $parameters, $absolute);
+                return $router->generate($name, $parameters, $referenceType);
             } catch (RouteNotFoundException $e) {
                 $hint = $this->getErrorMessage($name, $router, is_array($parameters) ? $parameters : array());
                 $debug[] = $hint;

--- a/ContentAwareGenerator.php
+++ b/ContentAwareGenerator.php
@@ -65,7 +65,7 @@ class ContentAwareGenerator extends ProviderBasedGenerator
      *
      * @throws RouteNotFoundException If there is no such route in the database
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
         if ($name instanceof SymfonyRoute) {
             $route = $this->getBestLocaleRoute($name, $parameters);
@@ -82,7 +82,7 @@ class ContentAwareGenerator extends ProviderBasedGenerator
 
         $this->unsetLocaleIfNotNeeded($route, $parameters);
 
-        return parent::generate($route, $parameters, $absolute);
+        return parent::generate($route, $parameters, $referenceType);
     }
 
     /**

--- a/DynamicRouter.php
+++ b/DynamicRouter.php
@@ -149,24 +149,11 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
     }
 
     /**
-     * Generates a URL from the given parameters.
-     *
-     * If the generator is not able to generate the url, it must throw the
-     * RouteNotFoundException as documented below.
-     *
-     * @param string  $name       The name of the route
-     * @param mixed   $parameters An array of parameters
-     * @param Boolean $absolute   Whether to generate an absolute URL
-     *
-     * @return string The generated URL
-     *
-     * @throws RouteNotFoundException if route doesn't exist
-     *
-     * @api
+     * {@inheritDoc}
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
-        return $this->getGenerator()->generate($name, $parameters, $absolute);
+        return $this->getGenerator()->generate($name, $parameters, $referenceType);
     }
 
     /**

--- a/ProviderBasedGenerator.php
+++ b/ProviderBasedGenerator.php
@@ -46,7 +46,7 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
     /**
      * {@inheritDoc}
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
         if ($name instanceof SymfonyRoute) {
             $route = $name;
@@ -60,7 +60,7 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
 
         $debug_message = $this->getRouteDebugMessage($name);
 
-        return $this->doGenerate($compiledRoute->getVariables(), $route->getDefaults(), $route->getRequirements(), $compiledRoute->getTokens(), $parameters, $debug_message, $absolute, $hostTokens);
+        return $this->doGenerate($compiledRoute->getVariables(), $route->getDefaults(), $route->getRequirements(), $compiledRoute->getTokens(), $parameters, $debug_message, $referenceType, $hostTokens);
     }
 
     /**

--- a/Tests/Routing/ChainRouterTest.php
+++ b/Tests/Routing/ChainRouterTest.php
@@ -493,13 +493,13 @@ class ChainRouterTest extends CmfUnitTestCase
         $high
             ->expects($this->once())
             ->method('generate')
-            ->with($name, $parameters, false)
+            ->with($name, $parameters, RouterInterface::ABSOLUTE_PATH)
             ->will($this->throwException(new RouteNotFoundException()))
         ;
         $low
             ->expects($this->once())
             ->method('generate')
-            ->with($name, $parameters, false)
+            ->with($name, $parameters, RouterInterface::ABSOLUTE_PATH)
             ->will($this->returnValue($url))
         ;
         $lower
@@ -528,7 +528,7 @@ class ChainRouterTest extends CmfUnitTestCase
         $router
             ->expects($this->once())
             ->method('generate')
-            ->with($name, null, false)
+            ->with($name, null, RouterInterface::ABSOLUTE_PATH)
             ->will($this->throwException(new RouteNotFoundException()))
         ;
         $router
@@ -556,12 +556,12 @@ class ChainRouterTest extends CmfUnitTestCase
         $high
             ->expects($this->once())
             ->method('generate')
-            ->with($name, $parameters, false)
+            ->with($name, $parameters, RouterInterface::ABSOLUTE_PATH)
             ->will($this->throwException(new RouteNotFoundException()))
         ;
         $low->expects($this->once())
             ->method('generate')
-            ->with($name, $parameters, false)
+            ->with($name, $parameters, RouterInterface::ABSOLUTE_PATH)
             ->will($this->throwException(new RouteNotFoundException()))
         ;
         $this->router->add($low, 10);
@@ -610,7 +610,7 @@ class ChainRouterTest extends CmfUnitTestCase
         ;
         $chainedRouter->expects($this->once())
             ->method('generate')
-            ->with($name, $parameters, false)
+            ->with($name, $parameters, RouterInterface::ABSOLUTE_PATH)
             ->will($this->throwException(new RouteNotFoundException()))
         ;
         $chainedRouter->expects($this->once())
@@ -644,7 +644,7 @@ class ChainRouterTest extends CmfUnitTestCase
         $chainedRouter
             ->expects($this->once())
             ->method('generate')
-            ->with($name, $parameters, false)
+            ->with($name, $parameters, RouterInterface::ABSOLUTE_PATH)
             ->will($this->returnValue($name))
         ;
 

--- a/Tests/Routing/ContentAwareGeneratorTest.php
+++ b/Tests/Routing/ContentAwareGeneratorTest.php
@@ -24,7 +24,7 @@ class ContentAwareGeneratorTest extends CmfUnitTestCase
     protected $provider;
 
     /**
-     * @var ContentAwareGenerator
+     * @var TestableContentAwareGenerator
      */
     protected $generator;
     protected $context;

--- a/Tests/Routing/DynamicRouterTest.php
+++ b/Tests/Routing/DynamicRouterTest.php
@@ -92,15 +92,14 @@ class DynamicRouterTest extends CmfUnitTestCase
     {
         $name = 'my_route_name';
         $parameters = array('foo' => 'bar');
-        $absolute = true;
 
         $this->generator->expects($this->once())
             ->method('generate')
-            ->with($name, $parameters, $absolute)
+            ->with($name, $parameters, DynamicRouter::ABSOLUTE_URL)
             ->will($this->returnValue('http://test'))
         ;
 
-        $url = $this->router->generate($name, $parameters, $absolute);
+        $url = $this->router->generate($name, $parameters, DynamicRouter::ABSOLUTE_URL);
         $this->assertEquals('http://test', $url);
     }
 


### PR DESCRIPTION
The `UrlGeneratorInterface::generate` method uses a "referenceType" instead of "absolute" parameter since symfony version 2.2. The important part is to use the constants as the old values of those are deprecated in 2.8: symfony/symfony#16276

I don't know if 1.3 is the correct target branch. If it should be applied somewhere else, please do so.