### PR TITLE
use the request context to rebuild the request on matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* **2016-01-09**: When ChainRouter::match is used with a RequestMatcher, the
+  Request is now properly rebuilt from the RequestContext if that was set on
+  the ChainRouter.
 * **2014-09-29**: ChainRouter does not require a RouterInterface, as a
   RequestMatcher and UrlGenerator is fine too. Fixed chain router interface to
   not force a RouterInterface.

--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -180,11 +180,12 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
                 // matching requests is more powerful than matching URLs only, so try that first
                 if ($router instanceof RequestMatcherInterface) {
                     if (empty($requestForMatching)) {
-                        $requestForMatching = Request::create($url);
+                        $requestForMatching = $this->rebuildRequest($url);
                     }
 
                     return $router->matchRequest($requestForMatching);
                 }
+
                 // every router implements the match method
                 return $router->match($url);
             } catch (ResourceNotFoundException $e) {
@@ -247,6 +248,51 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
         }
 
         throw new RouteNotFoundException(sprintf('None of the chained routers were able to generate route: %s', $info));
+    }
+
+    /**
+     * Rebuild the request object from a URL with the help of the RequestContext.
+     *
+     * If the request context is not set, this simply returns the request object built from $uri.
+     *
+     * @param string $uri
+     *
+     * @return Request
+     */
+    private function rebuildRequest($uri)
+    {
+        if (!$this->context) {
+            return Request::create($uri);
+        }
+
+        $server = array();
+        if ($this->context->getHost()) {
+            $server['SERVER_NAME'] = $this->context->getHost();
+            $server['HTTP_HOST'] = $this->context->getHost();
+        }
+        if ($this->context->getBaseUrl()) {
+            $uri = $this->context->getBaseUrl().$uri;
+            $server['SCRIPT_FILENAME'] = $this->context->getBaseUrl();
+            $server['PHP_SELF'] = $this->context->getBaseUrl();
+        }
+        if ('https' === $this->context->getScheme()) {
+            $server['HTTPS'] = 'on';
+            $server['SERVER_PORT'] = $this->context->getHttpsPort();
+            if (443 !== $this->context->getHttpsPort()) {
+                // this is parsed from the host by symfony request
+                // https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Request.php#L971
+                $server['HTTP_HOST'] .= ':'.$this->context->getHttpsPort();
+            }
+        } else {
+            $server['SERVER_PORT'] = $this->context->getHttpPort();
+            if (80 !== $this->context->getHttpPort()) {
+                // this is parsed from the host by symfony request
+                // https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Request.php#L971
+                $server['HTTP_HOST'] .= ':'.$this->context->getHttpPort();
+            }
+        }
+
+        return Request::create($uri, $this->context->getMethod(), $this->context->getParameters(), array(), array(), $server);
     }
 
     private function getErrorMessage($name, $router = null, $parameters = null)


### PR DESCRIPTION
this is an alternative to #147 / #152 without BC breaks.

/cc @pk16011990 @sustmi would that solve your situation? if you set the request context on the router, you will no longer run into the problem with the double leading // making symfony thing the path is the domain.