### PR TITLE
Refactored Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+dist: trusty
 php:
   - 7.0
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 matrix:
   include:
     - php: 7.1
-      env: SYMFONY_VERSION=3.3.* DEPS=dev
+      env: SYMFONY_VERSION=3.3.* STABILITY=dev
     - php: 5.6
       env: SYMFONY_VERSION=2.8.* COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.1
@@ -32,8 +32,8 @@ before_install:
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   - phpenv config-rm xdebug.ini || true
   - composer self-update
-  - if [ "$DEPS" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
+  - ${STABILITY:+ composer config 'minimum-stability' "$STABILITY"}
+  - ${SYMFONY_VERSION:+ composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update}
 
 install: composer update --prefer-dist $COMPOSER_FLAGS
 


### PR DESCRIPTION
What's about the [email notifications](https://github.com/symfony-cmf/routing/pull/196/files?diff=split#diff-354f30a63fb0907d4ad57269548329e3R44) ?

Only the IRC notifications are configured for the _Routing Auto_ component/bundle repository. Is it an oversight ? Or is this email no more used ?