### PR TITLE
PHP 7.2 compatibility: check if sortedRouters is null before trying to count it

### DIFF
--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -47,7 +47,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
     /**
      * @var RouterInterface[] Array of routers, sorted by priority
      */
-    private $sortedRouters;
+    private $sortedRouters = [];
 
     /**
      * @var RouteCollection


### PR DESCRIPTION
Starting from PHP 7.2, `count(null)` yields a warning (see https://3v4l.org/hbmpC).

Alternatively `sortedRouters` could be initialized as empty array and trigger a sort if count of `sortedRouters` differs from `routers` , but I don't know the exact background of this logic.