### PR TITLE
Make ChainRouter work with PHP 7.2

### DIFF
--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -98,7 +98,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
      */
     public function all()
     {
-        if (0 === count($this->sortedRouters)) {
+        if (null === $this->sortedRouters || 0 === count($this->sortedRouters)) {
             $this->sortedRouters = $this->sortRouters();
 
             // setContext() is done here instead of in add() to avoid fatal errors when clearing and warming up caches


### PR DESCRIPTION
Currently the chain router fails in symfony context with 
```
In ChainRouter.php line 101:
                                                                                       
  [Symfony\Component\Debug\Exception\ContextErrorException]                            
  Warning: count(): Parameter must be an array or an object that implements Countable

```

This is because the sortedRouters property is not initialized.

The change proposes to take the not initialized property into account while fetching all routes.