### PR TITLE
Support Symfony 4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/routing": "^2.8|^3.0",
-        "symfony/http-kernel": "^2.8|^3.0",
+        "symfony/routing": "^2.8|^3.0|^4.0",
+        "symfony/http-kernel": "^2.8|^3.0|^4.0",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.2",
-        "symfony/dependency-injection": "^2.8|^3.0",
-        "symfony/config": "^2.8|^3.0",
-        "symfony/event-dispatcher": "^2.8|^3.0",
+        "symfony/phpunit-bridge": "^3.2|^4.0",
+        "symfony/dependency-injection": "^2.8|^3.0|^4.0",
+        "symfony/config": "^2.8|^3.0|^4.0",
+        "symfony/event-dispatcher": "^2.8|^3.0|^4.0",
         "friendsofsymfony/jsrouting-bundle": "^1.1",
         "symfony-cmf/testing": "^2.1@dev"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | none
| License       | MIT
| Doc PR        | N/A

This PR adds Symfony 4 to the composer.json file. The tests passed without modification. However, the library pulls dependencies that still depend on Symfony 3.x.

#SymfonyConHackday2017