### PR TITLE
avoid error with non-array parameters

### DIFF
--- a/ChainRouter.php
+++ b/ChainRouter.php
@@ -288,7 +288,8 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
     private function getErrorMessage($name, $router = null, $parameters = null)
     {
         if ($router instanceof VersatileGeneratorInterface) {
-            $displayName = $router->getRouteDebugMessage($name, $parameters);
+            // the $parameters are not forced to be array, but versatile generator does typehint it
+            $displayName = $router->getRouteDebugMessage($name, is_array($parameters) ? $parameters : array());
         } elseif (is_object($name)) {
             $displayName = method_exists($name, '__toString')
                 ? (string) $name


### PR DESCRIPTION
The UrlGeneratorInterface::generate is not very specific about $parameters and allows non-arrays.
I don't want to get more fancy than this, its only about a very edge-case in error reporting in the end.

| Q             | A
| ------------- | ---
| Branch?       | 1.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
