### PR TITLE
avoid error during error reporting in chain router

### DIFF
--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -288,6 +288,10 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
     private function getErrorMessage($name, $router = null, $parameters = null)
     {
         if ($router instanceof VersatileGeneratorInterface) {
+            // the $parameters are not forced to be array, but versatile generator does typehint it
+            if (!is_array($parameters)) {
+                $parameters = [];
+            }
             $displayName = $router->getRouteDebugMessage($name, $parameters);
         } elseif (is_object($name)) {
             $displayName = method_exists($name, '__toString')


### PR DESCRIPTION
The UrlGeneratorInterface::generate is not very specific about $parameters and allows non-arrays.
I don't want to get more fancy than this, its only about a very edge-case in error reporting in the end.

| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
