### PR TITLE
Initialize context in constructor of chainrouter.

### DIFF
--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -64,7 +64,8 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
      */
     public function __construct(LoggerInterface $logger = null)
     {
-        $this->logger = $logger;
+        $this->logger = $logger;      
+        $this->context = new RequestContext();
     }
 
     /**


### PR DESCRIPTION
Initialize the requestcontext in the contstructor of the chainrouter to avoid getContext() to return null

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | #218 
| License       | MIT
| Doc PR        | 
