### PR TITLE
Initialize request context if none has been set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 2.1.0 (unreleased)
 ------------------
 
-* **2017-10-23**: Dropped php hhvm support
+* ChainRouter now returns a new RequestContext if none has been set, to be closer in behaviour to the Symfony router.
+* Dropped php hhvm support
 
 2.0.3
 -----


### PR DESCRIPTION
Symfony core router never returns null in getContext() and some third party code relies on that behaviour.

Wrapping up #219 

| Q             | A
| ------------- | ---
| Bug fix?      | kindof
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fix #219, #218
| License       | MIT
| Doc PR        | -
