### PR TITLE
Fixing https://github.com/symfony-cmf/Routing/issues/236

### DIFF
--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -232,7 +232,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
      *
      * @param mixed $name       the name of the route or something identifying a route that can be used by any of
      *                          the chained routers
-     * @param mixed $parameters An array of parameters
+     * @param array $parameters An array of parameters
      * @param int   $absolute   The type of reference to be generated (one of the constants)
      *
      * @return string The generated URL


### PR DESCRIPTION
The ChainRouter::generate function has a wider type for the name parameter than
the UrlGeneratorInterface.

Some analysis tools like PHPStan check the PHPDoc to make sure the correct
types are used.

With this change the PHPDoc for ChainRouter::generate reflects the widened type.

| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 236
| License       | MIT
| Doc PR        | reference to the documentation PR, if any
