### PR TITLE
Symfony 5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 phpunit.xml
 composer.lock
 /vendor/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 
@@ -36,12 +35,12 @@ env:
 
 matrix:
   include:
-    - php: 7.1
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_REQUIRE=3.4.* SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 7.4
-      env: SYMFONY_REQUIRE=4.3.*
+    - php: 7.2
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_REQUIRE=4.4.* SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.4
       env: SYMFONY_REQUIRE=4.4.*
+    - php: 7.4
+      env: SYMFONY_REQUIRE=5.0.*
   fast_finish: true
   allow_failures:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.3.0
+-----
+
+* Dropped support for PHP 7.1 and symfony 3.4 and 4.3.
+* Added support for symfony 5.
+* Deprecated passing a route object as the $name parameter in the generate method of the ChainRouter and the DynamicRouter.
+* The VersatileGeneratorInterface is deprecated.
+
 2.1.1
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev"
+            "dev-master": "2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,20 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "symfony/routing": "^3.4 || ^4.3",
-        "symfony/http-kernel": "^3.4 || ^4.3",
+        "php": "^7.2",
+        "symfony/routing": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.2.2",
-        "symfony/dependency-injection": "^3.4 || ^4.3",
-        "symfony/config": "^3.4 || ^4.3",
-        "symfony/event-dispatcher": "^3.4 || ^4.3",
+        "symfony/phpunit-bridge": "^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.0",
         "symfony-cmf/testing": "^3@dev"
     },
     "suggest": {
-        "symfony/event-dispatcher": "DynamicRouter can optionally trigger an event at the start of matching. Minimal version (^3.4 || ^4.3)"
+        "symfony/event-dispatcher": "DynamicRouter can optionally trigger an event at the start of matching. Minimal version (^4.4 || ^5.0)"
     },
     "autoload": {
         "psr-4": {

--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -231,19 +231,8 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
                 continue;
             }
 
-            // if $router does not announce it is capable of handling
-            // non-string routes and the ROUTE_OBJECT is set in the parameters array, continue
-            if (array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters) && is_object($parameters[RouteObjectInterface::ROUTE_OBJECT]) && !$router instanceof VersatileGeneratorInterface) {
-                continue;
-            }
-
-            $routeName = $name;
-            if (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name && array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters) && is_object($parameters[RouteObjectInterface::ROUTE_OBJECT])) {
-                $routeName = $parameters[RouteObjectInterface::ROUTE_OBJECT];
-            }
-
             // If $router is versatile and doesn't support this route name, continue
-            if ($router instanceof VersatileGeneratorInterface && !$router->supports($routeName)) {
+            if ($router instanceof VersatileGeneratorInterface && !$router->supports($name)) {
                 continue;
             }
 

--- a/src/ContentAwareGenerator.php
+++ b/src/ContentAwareGenerator.php
@@ -70,6 +70,8 @@ class ContentAwareGenerator extends ProviderBasedGenerator
     {
         if ($name instanceof SymfonyRoute) {
             $route = $this->getBestLocaleRoute($name, $parameters);
+        } elseif (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name && array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters) && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof SymfonyRoute) {
+            $route = $this->getBestLocaleRoute($parameters[RouteObjectInterface::ROUTE_OBJECT], $parameters);
         } elseif (is_string($name) && $name) {
             $route = $this->getRouteByName($name, $parameters);
         } else {
@@ -165,6 +167,8 @@ class ContentAwareGenerator extends ProviderBasedGenerator
     {
         if ($name instanceof RouteReferrersReadInterface) {
             $content = $name;
+        } elseif (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name && array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters) && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof RouteReferrersReadInterface) {
+            $content = $parameters[RouteObjectInterface::ROUTE_OBJECT];
         } elseif (array_key_exists('content_id', $parameters)
             && null !== $this->contentRepository
         ) {

--- a/src/DynamicRouter.php
+++ b/src/DynamicRouter.php
@@ -173,9 +173,13 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
      */
     public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
+        if (is_object($name)) {
+            @trigger_error(sprintf('Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "%s" parameter in the parameters array.', RouteObjectInterface::ROUTE_OBJECT), E_USER_DEPRECATED);
+        }
+
         if ($this->eventDispatcher) {
             $event = new RouterGenerateEvent($name, $parameters, $referenceType);
-            $this->eventDispatcher->dispatch(Events::PRE_DYNAMIC_GENERATE, $event);
+            $this->eventDispatcher->dispatch($event, Events::PRE_DYNAMIC_GENERATE);
             $name = $event->getRoute();
             $parameters = $event->getParameters();
             $referenceType = $event->getReferenceType();
@@ -224,7 +228,7 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
         $request = Request::create($pathinfo);
         if ($this->eventDispatcher) {
             $event = new RouterMatchEvent();
-            $this->eventDispatcher->dispatch(Events::PRE_DYNAMIC_MATCH, $event);
+            $this->eventDispatcher->dispatch($event, Events::PRE_DYNAMIC_MATCH);
         }
 
         if (!empty($this->uriFilterRegexp) && !preg_match($this->uriFilterRegexp, $pathinfo)) {
@@ -260,7 +264,7 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
     {
         if ($this->eventDispatcher) {
             $event = new RouterMatchEvent($request);
-            $this->eventDispatcher->dispatch(Events::PRE_DYNAMIC_MATCH_REQUEST, $event);
+            $this->eventDispatcher->dispatch($event, Events::PRE_DYNAMIC_MATCH_REQUEST);
         }
 
         if ($this->uriFilterRegexp

--- a/src/DynamicRouter.php
+++ b/src/DynamicRouter.php
@@ -89,12 +89,13 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
      *
      * @throws \InvalidArgumentException If the matcher is not a request or url matcher
      */
-    public function __construct(RequestContext $context,
-                                $matcher,
-                                UrlGeneratorInterface $generator,
-                                $uriFilterRegexp = '',
-                                EventDispatcherInterface $eventDispatcher = null,
-                                RouteProviderInterface $provider = null
+    public function __construct(
+        RequestContext $context,
+        $matcher,
+        UrlGeneratorInterface $generator,
+        $uriFilterRegexp = '',
+        EventDispatcherInterface $eventDispatcher = null,
+        RouteProviderInterface $provider = null
     ) {
         $this->context = $context;
         if (!$matcher instanceof RequestMatcherInterface && !$matcher instanceof UrlMatcherInterface) {

--- a/src/Event/RouterGenerateEvent.php
+++ b/src/Event/RouterGenerateEvent.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Cmf\Component\Routing\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Routing\Route;
 
 /**

--- a/src/Event/RouterGenerateEvent.php
+++ b/src/Event/RouterGenerateEvent.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Cmf\Component\Routing\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Routing\Route;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event fired before the dynamic router generates a url for a route.

--- a/src/Event/RouterMatchEvent.php
+++ b/src/Event/RouterMatchEvent.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Cmf\Component\Routing\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 
 class RouterMatchEvent extends Event

--- a/src/Event/RouterMatchEvent.php
+++ b/src/Event/RouterMatchEvent.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Cmf\Component\Routing\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class RouterMatchEvent extends Event
 {

--- a/src/RouteObjectInterface.php
+++ b/src/RouteObjectInterface.php
@@ -57,6 +57,11 @@ interface RouteObjectInterface
     const CONTENT_ID = '_content_id';
 
     /**
+     * Route name used when passing a route object to the generator in $parameters[RouteObjectInterface::ROUTE_OBJECT].
+     */
+    const OBJECT_BASED_ROUTE_NAME = 'cmf_routing_object';
+
+    /**
      * Get the content document this route entry stands for. If non-null,
      * the ControllerClassMapper uses it to identify a controller and
      * the content is passed to the controller.

--- a/src/VersatileGeneratorInterface.php
+++ b/src/VersatileGeneratorInterface.php
@@ -16,6 +16,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * This generator is able to handle more than string route names as symfony
  * core supports them.
+ *
+ * @deprecated The "Symfony\Cmf\Component\Routing\VersatileGeneratorInterface" is deprecated in symfony-cmf/Routing v2.3 and will be removed in symfony-cmf/Routing v3.O. Use the "_route_object" parameter instead to handle route objects
  */
 interface VersatileGeneratorInterface extends UrlGeneratorInterface
 {

--- a/tests/Unit/Routing/ChainRouterTest.php
+++ b/tests/Unit/Routing/ChainRouterTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Loader\ObjectRouteLoader;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
@@ -612,9 +613,16 @@ class ChainRouterTest extends TestCase
 
     /**
      * Route is an object but no versatile generator around to do the debug message.
+     *
+     * @group legacy
+     * @expectedDeprecation Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "_route_object" parameter in the parameters array.
      */
     public function testGenerateObjectNotFound()
     {
+        if (!class_exists(ObjectRouteLoader::class)) {
+            $this->markTestSkipped('Skip this test on >= sf5. This will throw a \TypeError.');
+        }
+
         $name = new \stdClass();
         $parameters = ['test' => 'value'];
 
@@ -633,9 +641,16 @@ class ChainRouterTest extends TestCase
 
     /**
      * A versatile router will generate the debug message.
+     *
+     * @group legacy
+     * @expectedDeprecation Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "_route_object" parameter in the parameters array.
      */
     public function testGenerateObjectNotFoundVersatile()
     {
+        if (!class_exists(ObjectRouteLoader::class)) {
+            $this->markTestSkipped('Skip this test on >= sf5. This will throw a \TypeError.');
+        }
+
         $name = new \stdClass();
         $parameters = ['test' => 'value'];
 
@@ -662,8 +677,16 @@ class ChainRouterTest extends TestCase
         $this->router->generate($name, $parameters);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "_route_object" parameter in the parameters array.
+     */
     public function testGenerateObjectName()
     {
+        if (!class_exists(ObjectRouteLoader::class)) {
+            $this->markTestSkipped('Skip this test on >= sf5. This will throw a \TypeError.');
+        }
+
         $name = new \stdClass();
         $parameters = ['test' => 'value'];
 

--- a/tests/Unit/Routing/ChainRouterTest.php
+++ b/tests/Unit/Routing/ChainRouterTest.php
@@ -393,8 +393,9 @@ class ChainRouterTest extends TestCase
             ->expects($this->once())
             ->method('match')
             ->with($url)
-            ->will($this->returnValue(['test']
-    ))
+            ->will($this->returnValue(
+                ['test']
+            ))
         ;
         $this->router->add($low, 10);
         $this->router->add($high, 100);

--- a/tests/Unit/Routing/ContentAwareGeneratorTest.php
+++ b/tests/Unit/Routing/ContentAwareGeneratorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Cmf\Component\Routing\ContentAwareGenerator;
 use Symfony\Cmf\Component\Routing\ContentRepositoryInterface;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
 use Symfony\Cmf\Component\Routing\Tests\Unit\Routing\RouteMock;
@@ -85,6 +86,19 @@ class ContentAwareGeneratorTest extends TestCase
         ;
 
         $this->assertEquals('result_url', $this->generator->generate($this->contentDocument));
+    }
+
+    public function testGenerateFromContentInParameters()
+    {
+        $this->provider->expects($this->never())
+            ->method('getRouteByName')
+        ;
+        $this->routeDocument->expects($this->once())
+            ->method('compile')
+            ->willReturn($this->routeCompiled)
+        ;
+
+        $this->assertEquals('result_url', $this->generator->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, [RouteObjectInterface::ROUTE_OBJECT => $this->routeDocument]));
     }
 
     public function testGenerateFromContentId()

--- a/tests/Unit/Routing/DynamicRouterTest.php
+++ b/tests/Unit/Routing/DynamicRouterTest.php
@@ -338,7 +338,7 @@ class DynamicRouterTest extends TestCase
 
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(Events::PRE_DYNAMIC_MATCH, $this->equalTo(new RouterMatchEvent()))
+            ->with($this->equalTo(new RouterMatchEvent()), Events::PRE_DYNAMIC_MATCH)
         ;
 
         $routeDefaults = ['foo' => 'bar'];
@@ -359,12 +359,12 @@ class DynamicRouterTest extends TestCase
         $that = $this;
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(Events::PRE_DYNAMIC_MATCH_REQUEST, $this->callback(function ($event) use ($that) {
+            ->with($this->callback(function ($event) use ($that) {
                 $that->assertInstanceOf(RouterMatchEvent::class, $event);
                 $that->assertEquals($that->request, $event->getRequest());
 
                 return true;
-            }))
+            }), Events::PRE_DYNAMIC_MATCH_REQUEST)
         ;
 
         $routeDefaults = ['foo' => 'bar'];
@@ -392,7 +392,7 @@ class DynamicRouterTest extends TestCase
         $that = $this;
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(Events::PRE_DYNAMIC_GENERATE, $this->callback(function ($event) use ($that, $oldname, $newname, $oldparameters, $newparameters, $oldReferenceType, $newReferenceType) {
+            ->with($this->callback(function ($event) use ($that, $oldname, $newname, $oldparameters, $newparameters, $oldReferenceType, $newReferenceType) {
                 $that->assertInstanceOf(RouterGenerateEvent::class, $event);
                 if (empty($that->seen)) {
                     // phpunit is calling the callback twice, and because we update the event the second time fails
@@ -408,7 +408,7 @@ class DynamicRouterTest extends TestCase
                 $event->setReferenceType($newReferenceType);
 
                 return true;
-            }))
+            }), Events::PRE_DYNAMIC_GENERATE)
         ;
 
         $this->generator->expects($this->once())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

As discussed in #245 this PR adds symfony support without the required bc layer for objects as routeName. I've bumped the php version to 7.2 to allow us to keep the current generator signature for now, which allows for an easier upgrade. 

@dbu should I open a PR for the dev-kit to bump the php version tested in travis? 
