### PR TITLE
Acrobat symfony5 support 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 phpunit.xml
 composer.lock
 /vendor/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 
@@ -36,12 +35,12 @@ env:
 
 matrix:
   include:
-    - php: 7.1
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_REQUIRE=3.4.* SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 7.4
-      env: SYMFONY_REQUIRE=4.3.*
+    - php: 7.2
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_REQUIRE=4.4.* SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.4
       env: SYMFONY_REQUIRE=4.4.*
+    - php: 7.4
+      env: SYMFONY_REQUIRE=5.0.*
   fast_finish: true
   allow_failures:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Changelog
   name `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` (`cmf_routing_object`)
   and pass the route object in the parameters with key
   `RouteObjectInterface::ROUTE_OBJECT` (`_route_object`).
-* The VersatileGeneratorInterface is deprecated as it was used to avoid errors
-  with routers not supporting objects in `$name`.
+* The VersatileGeneratorInterface::supports method is deprecated as it was used
+  to avoid errors with routers not supporting objects in `$name`.
 
 2.2.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 Changelog
 =========
 
+2.3.0
+-----
+
+* Dropped support for PHP 7.1 and Symfony 3.4 and 4.3.
+* Added support for Symfony 5.
+* Deprecated passing a route object (or anything else that is not a string) as
+  the `$name` parameter in the `generate` method of the ChainRouter and the
+  DynamicRouter. Symfony 5 enforces the `$name` parameter to be a string with
+  static type declaration.
+  The future proof way to generate a route from an object is to use the route
+  name `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` (`cmf_routing_object`)
+  and pass the route object in the parameters with key
+  `RouteObjectInterface::ROUTE_OBJECT` (`_route_object`).
+* The VersatileGeneratorInterface is deprecated as it was used to avoid errors
+  with routers not supporting objects in `$name`.
+
+2.2.0
+-----
+
+* Avoid Symfony 4.3 event dispatcher deprecation warnings.
+
 2.1.1
 -----
 
@@ -36,7 +57,7 @@ Released.
 ---------
 
  * **2016-11-30**: Changed file structure to have all php code in src/
- 
+
 1.4.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev"
+            "dev-master": "2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,20 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "symfony/routing": "^3.4 || ^4.3",
-        "symfony/http-kernel": "^3.4 || ^4.3",
+        "php": "^7.2",
+        "symfony/routing": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.2.2",
-        "symfony/dependency-injection": "^3.4 || ^4.3",
-        "symfony/config": "^3.4 || ^4.3",
-        "symfony/event-dispatcher": "^3.4 || ^4.3",
+        "symfony/phpunit-bridge": "^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.0",
         "symfony-cmf/testing": "^3@dev"
     },
     "suggest": {
-        "symfony/event-dispatcher": "DynamicRouter can optionally trigger an event at the start of matching. Minimal version (^3.4 || ^4.3)"
+        "symfony/event-dispatcher": "DynamicRouter can optionally trigger an event at the start of matching. Minimal version (^4.4 || ^5.0)"
     },
     "autoload": {
         "psr-4": {

--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -231,19 +231,8 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
                 continue;
             }
 
-            // if $router does not announce it is capable of handling
-            // non-string routes and the ROUTE_OBJECT is set in the parameters array, continue
-            if (array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters) && is_object($parameters[RouteObjectInterface::ROUTE_OBJECT]) && !$router instanceof VersatileGeneratorInterface) {
-                continue;
-            }
-
-            $routeName = $name;
-            if (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name && array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters) && is_object($parameters[RouteObjectInterface::ROUTE_OBJECT])) {
-                $routeName = $parameters[RouteObjectInterface::ROUTE_OBJECT];
-            }
-
             // If $router is versatile and doesn't support this route name, continue
-            if ($router instanceof VersatileGeneratorInterface && !$router->supports($routeName)) {
+            if ($router instanceof VersatileGeneratorInterface && !$router->supports($name)) {
                 continue;
             }
 

--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -219,7 +219,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
     public function generate($name, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         if (is_object($name)) {
-            @trigger_error(sprintf('Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "%s" parameter in the parameters array.', RouteObjectInterface::ROUTE_OBJECT), E_USER_DEPRECATED);
+            @trigger_error('Passing an object as route name is deprecated since version 2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.', E_USER_DEPRECATED);
         }
 
         $debug = [];

--- a/src/ContentAwareGenerator.php
+++ b/src/ContentAwareGenerator.php
@@ -70,6 +70,8 @@ class ContentAwareGenerator extends ProviderBasedGenerator
     {
         if ($name instanceof SymfonyRoute) {
             $route = $this->getBestLocaleRoute($name, $parameters);
+        } elseif (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name && array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters) && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof SymfonyRoute) {
+            $route = $this->getBestLocaleRoute($parameters[RouteObjectInterface::ROUTE_OBJECT], $parameters);
         } elseif (is_string($name) && $name) {
             $route = $this->getRouteByName($name, $parameters);
         } else {
@@ -165,6 +167,8 @@ class ContentAwareGenerator extends ProviderBasedGenerator
     {
         if ($name instanceof RouteReferrersReadInterface) {
             $content = $name;
+        } elseif (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name && array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters) && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof RouteReferrersReadInterface) {
+            $content = $parameters[RouteObjectInterface::ROUTE_OBJECT];
         } elseif (array_key_exists('content_id', $parameters)
             && null !== $this->contentRepository
         ) {

--- a/src/DynamicRouter.php
+++ b/src/DynamicRouter.php
@@ -175,7 +175,7 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
     public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         if (is_object($name)) {
-            @trigger_error(sprintf('Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "%s" parameter in the parameters array.', RouteObjectInterface::ROUTE_OBJECT), E_USER_DEPRECATED);
+            @trigger_error('Passing an object as route name is deprecated since version 2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT', E_USER_DEPRECATED);
         }
 
         if ($this->eventDispatcher) {

--- a/src/DynamicRouter.php
+++ b/src/DynamicRouter.php
@@ -174,9 +174,13 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
      */
     public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
+        if (is_object($name)) {
+            @trigger_error(sprintf('Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "%s" parameter in the parameters array.', RouteObjectInterface::ROUTE_OBJECT), E_USER_DEPRECATED);
+        }
+
         if ($this->eventDispatcher) {
             $event = new RouterGenerateEvent($name, $parameters, $referenceType);
-            $this->eventDispatcher->dispatch(Events::PRE_DYNAMIC_GENERATE, $event);
+            $this->eventDispatcher->dispatch($event, Events::PRE_DYNAMIC_GENERATE);
             $name = $event->getRoute();
             $parameters = $event->getParameters();
             $referenceType = $event->getReferenceType();
@@ -225,7 +229,7 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
         $request = Request::create($pathinfo);
         if ($this->eventDispatcher) {
             $event = new RouterMatchEvent();
-            $this->eventDispatcher->dispatch(Events::PRE_DYNAMIC_MATCH, $event);
+            $this->eventDispatcher->dispatch($event, Events::PRE_DYNAMIC_MATCH);
         }
 
         if (!empty($this->uriFilterRegexp) && !preg_match($this->uriFilterRegexp, $pathinfo)) {
@@ -261,7 +265,7 @@ class DynamicRouter implements RouterInterface, RequestMatcherInterface, Chained
     {
         if ($this->eventDispatcher) {
             $event = new RouterMatchEvent($request);
-            $this->eventDispatcher->dispatch(Events::PRE_DYNAMIC_MATCH_REQUEST, $event);
+            $this->eventDispatcher->dispatch($event, Events::PRE_DYNAMIC_MATCH_REQUEST);
         }
 
         if ($this->uriFilterRegexp

--- a/src/Event/RouterGenerateEvent.php
+++ b/src/Event/RouterGenerateEvent.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Cmf\Component\Routing\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Routing\Route;
 
 /**

--- a/src/Event/RouterGenerateEvent.php
+++ b/src/Event/RouterGenerateEvent.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Cmf\Component\Routing\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\Routing\Route;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event fired before the dynamic router generates a url for a route.

--- a/src/Event/RouterMatchEvent.php
+++ b/src/Event/RouterMatchEvent.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Cmf\Component\Routing\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 
 class RouterMatchEvent extends Event

--- a/src/Event/RouterMatchEvent.php
+++ b/src/Event/RouterMatchEvent.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Cmf\Component\Routing\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class RouterMatchEvent extends Event
 {

--- a/src/ProviderBasedGenerator.php
+++ b/src/ProviderBasedGenerator.php
@@ -77,10 +77,30 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
      */
     public function getRouteDebugMessage($name, array $parameters = [])
     {
+        if (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name
+            && array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)
+        ) {
+            $routeObject = $parameters[RouteObjectInterface::ROUTE_OBJECT];
+            if ($routeObject instanceof RouteObjectInterface) {
+                return 'Route with key '.$routeObject->getRouteKey();
+            }
+
+            if ($routeObject instanceof SymfonyRoute) {
+                return 'Route with path '.$routeObject->getPath();
+            }
+
+            if (is_object($routeObject)) {
+                return get_class($routeObject);
+            }
+
+            return 'Null route';
+        }
+
         if (is_scalar($name)) {
             return $name;
         }
 
+        // legacy
         if (is_array($name)) {
             return serialize($name);
         }

--- a/src/RouteObjectInterface.php
+++ b/src/RouteObjectInterface.php
@@ -57,6 +57,11 @@ interface RouteObjectInterface
     const CONTENT_ID = '_content_id';
 
     /**
+     * Route name used when passing a route object to the generator in $parameters[RouteObjectInterface::ROUTE_OBJECT].
+     */
+    const OBJECT_BASED_ROUTE_NAME = 'cmf_routing_object';
+
+    /**
      * Get the content document this route entry stands for. If non-null,
      * the ControllerClassMapper uses it to identify a controller and
      * the content is passed to the controller.

--- a/src/VersatileGeneratorInterface.php
+++ b/src/VersatileGeneratorInterface.php
@@ -16,6 +16,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * This generator is able to handle more than string route names as symfony
  * core supports them.
+ *
+ * @deprecated The "Symfony\Cmf\Component\Routing\VersatileGeneratorInterface" is deprecated in symfony-cmf/Routing v2.3 and will be removed in symfony-cmf/Routing v3.O. Use the "_route_object" parameter instead to handle route objects
  */
 interface VersatileGeneratorInterface extends UrlGeneratorInterface
 {

--- a/src/VersatileGeneratorInterface.php
+++ b/src/VersatileGeneratorInterface.php
@@ -14,10 +14,7 @@ namespace Symfony\Cmf\Component\Routing;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
- * This generator is able to handle more than string route names as symfony
- * core supports them.
- *
- * @deprecated The "Symfony\Cmf\Component\Routing\VersatileGeneratorInterface" is deprecated in symfony-cmf/Routing v2.3 and will be removed in symfony-cmf/Routing v3.O. Use the "_route_object" parameter instead to handle route objects
+ * This generator can provide additional information about the route that we wanted to generate.
  */
 interface VersatileGeneratorInterface extends UrlGeneratorInterface
 {
@@ -27,6 +24,13 @@ interface VersatileGeneratorInterface extends UrlGeneratorInterface
      * This check does not need to look if the specific instance can be
      * resolved to a route, only whether the router can generate routes from
      * objects of this class.
+     *
+     * @deprecated This method is deprecated since version 2.3 and will be
+     * removed in version 3.O.
+     *
+     * This method was used to not call generators that can not handle objects
+     * in $name. With Symfony 5, this becomes obsolete as the strict type
+     * declaration prevents passing anything else than a string as $name.
      *
      * @param mixed $name The route "name" which may also be an object or anything
      *
@@ -38,9 +42,8 @@ interface VersatileGeneratorInterface extends UrlGeneratorInterface
      * Convert a route identifier (name, content object etc) into a string
      * usable for logging and other debug/error messages.
      *
-     * @param mixed $name
-     * @param array $parameters which should contain a content field containing
-     *                          a RouteReferrersReadInterface object
+     * @param mixed $name       In Symfony 5, the name can only be a string
+     * @param array $parameters Which might hold a route object or content id or similar to include in the debug message
      *
      * @return string
      */

--- a/tests/Unit/Routing/ChainRouterTest.php
+++ b/tests/Unit/Routing/ChainRouterTest.php
@@ -617,12 +617,12 @@ class ChainRouterTest extends TestCase
      * Route is an object but no versatile generator around to do the debug message.
      *
      * @group legacy
-     * @expectedDeprecation Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "_route_object" parameter in the parameters array.
+     * @expectedDeprecation Passing an object as route name is deprecated since version 2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.
      */
     public function testGenerateObjectNotFound()
     {
         if (!class_exists(ObjectRouteLoader::class)) {
-            $this->markTestSkipped('Skip this test on >= sf5. This will throw a \TypeError.');
+            $this->markTestSkipped('Symfony 5 would throw a TypeError.');
         }
 
         $name = new \stdClass();
@@ -645,12 +645,12 @@ class ChainRouterTest extends TestCase
      * A versatile router will generate the debug message.
      *
      * @group legacy
-     * @expectedDeprecation Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "_route_object" parameter in the parameters array.
+     * @expectedDeprecation Passing an object as route name is deprecated since version 2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.
      */
     public function testGenerateObjectNotFoundVersatile()
     {
         if (!class_exists(ObjectRouteLoader::class)) {
-            $this->markTestSkipped('Skip this test on >= sf5. This will throw a \TypeError.');
+            $this->markTestSkipped('Symfony 5 would throw a TypeError.');
         }
 
         $name = new \stdClass();
@@ -681,12 +681,12 @@ class ChainRouterTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "_route_object" parameter in the parameters array.
+     * @expectedDeprecation Passing an object as route name is deprecated since version 2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.
      */
     public function testGenerateObjectName()
     {
         if (!class_exists(ObjectRouteLoader::class)) {
-            $this->markTestSkipped('Skip this test on >= sf5. This will throw a \TypeError.');
+            $this->markTestSkipped('Symfony 5 would throw a TypeError.');
         }
 
         $name = new \stdClass();
@@ -718,6 +718,9 @@ class ChainRouterTest extends TestCase
         $this->assertEquals($name, $result);
     }
 
+    /**
+     * This test currently triggers a deprecation notice because of ChainRouter BC.
+     */
     public function testGenerateWithObjectNameInParametersNotFoundVersatile()
     {
         $name = RouteObjectInterface::OBJECT_BASED_ROUTE_NAME;
@@ -757,13 +760,13 @@ class ChainRouterTest extends TestCase
             ->expects($this->once())
             ->method('generate')
             ->with($name, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH)
-            ->willReturn($name)
+            ->willReturn('/foo/bar')
         ;
 
         $this->router->add($defaultRouter, 200);
 
         $result = $this->router->generate($name, $parameters);
-        $this->assertEquals($name, $result);
+        $this->assertEquals('/foo/bar', $result);
     }
 
     public function testWarmup()
@@ -817,6 +820,9 @@ class ChainRouterTest extends TestCase
         $this->assertEquals(['high', 'low'], $names);
     }
 
+    /**
+     * @group legacy
+     */
     public function testSupport()
     {
         $router = $this->createMock(VersatileRouter::class);

--- a/tests/Unit/Routing/ChainRouterTest.php
+++ b/tests/Unit/Routing/ChainRouterTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Loader\ObjectRouteLoader;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
@@ -613,9 +614,16 @@ class ChainRouterTest extends TestCase
 
     /**
      * Route is an object but no versatile generator around to do the debug message.
+     *
+     * @group legacy
+     * @expectedDeprecation Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "_route_object" parameter in the parameters array.
      */
     public function testGenerateObjectNotFound()
     {
+        if (!class_exists(ObjectRouteLoader::class)) {
+            $this->markTestSkipped('Skip this test on >= sf5. This will throw a \TypeError.');
+        }
+
         $name = new \stdClass();
         $parameters = ['test' => 'value'];
 
@@ -634,9 +642,16 @@ class ChainRouterTest extends TestCase
 
     /**
      * A versatile router will generate the debug message.
+     *
+     * @group legacy
+     * @expectedDeprecation Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "_route_object" parameter in the parameters array.
      */
     public function testGenerateObjectNotFoundVersatile()
     {
+        if (!class_exists(ObjectRouteLoader::class)) {
+            $this->markTestSkipped('Skip this test on >= sf5. This will throw a \TypeError.');
+        }
+
         $name = new \stdClass();
         $parameters = ['test' => 'value'];
 
@@ -663,8 +678,16 @@ class ChainRouterTest extends TestCase
         $this->router->generate($name, $parameters);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing an object as the route name is deprecated in symfony-cmf/Routing v2.3 and will not work in Symfony 5.0. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` constant as the route name and the object as "_route_object" parameter in the parameters array.
+     */
     public function testGenerateObjectName()
     {
+        if (!class_exists(ObjectRouteLoader::class)) {
+            $this->markTestSkipped('Skip this test on >= sf5. This will throw a \TypeError.');
+        }
+
         $name = new \stdClass();
         $parameters = ['test' => 'value'];
 

--- a/tests/Unit/Routing/ContentAwareGeneratorTest.php
+++ b/tests/Unit/Routing/ContentAwareGeneratorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Cmf\Component\Routing\ContentAwareGenerator;
 use Symfony\Cmf\Component\Routing\ContentRepositoryInterface;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
 use Symfony\Cmf\Component\Routing\Tests\Unit\Routing\RouteMock;
@@ -85,6 +86,19 @@ class ContentAwareGeneratorTest extends TestCase
         ;
 
         $this->assertEquals('result_url', $this->generator->generate($this->contentDocument));
+    }
+
+    public function testGenerateFromContentInParameters()
+    {
+        $this->provider->expects($this->never())
+            ->method('getRouteByName')
+        ;
+        $this->routeDocument->expects($this->once())
+            ->method('compile')
+            ->willReturn($this->routeCompiled)
+        ;
+
+        $this->assertEquals('result_url', $this->generator->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, [RouteObjectInterface::ROUTE_OBJECT => $this->routeDocument]));
     }
 
     public function testGenerateFromContentId()

--- a/tests/Unit/Routing/DynamicRouterTest.php
+++ b/tests/Unit/Routing/DynamicRouterTest.php
@@ -338,7 +338,7 @@ class DynamicRouterTest extends TestCase
 
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(Events::PRE_DYNAMIC_MATCH, $this->equalTo(new RouterMatchEvent()))
+            ->with($this->equalTo(new RouterMatchEvent()), Events::PRE_DYNAMIC_MATCH)
         ;
 
         $routeDefaults = ['foo' => 'bar'];
@@ -359,12 +359,12 @@ class DynamicRouterTest extends TestCase
         $that = $this;
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(Events::PRE_DYNAMIC_MATCH_REQUEST, $this->callback(function ($event) use ($that) {
+            ->with($this->callback(function ($event) use ($that) {
                 $that->assertInstanceOf(RouterMatchEvent::class, $event);
                 $that->assertEquals($that->request, $event->getRequest());
 
                 return true;
-            }))
+            }), Events::PRE_DYNAMIC_MATCH_REQUEST)
         ;
 
         $routeDefaults = ['foo' => 'bar'];
@@ -392,7 +392,7 @@ class DynamicRouterTest extends TestCase
         $that = $this;
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(Events::PRE_DYNAMIC_GENERATE, $this->callback(function ($event) use ($that, $oldname, $newname, $oldparameters, $newparameters, $oldReferenceType, $newReferenceType) {
+            ->with($this->callback(function ($event) use ($that, $oldname, $newname, $oldparameters, $newparameters, $oldReferenceType, $newReferenceType) {
                 $that->assertInstanceOf(RouterGenerateEvent::class, $event);
                 if (empty($that->seen)) {
                     // phpunit is calling the callback twice, and because we update the event the second time fails
@@ -408,7 +408,7 @@ class DynamicRouterTest extends TestCase
                 $event->setReferenceType($newReferenceType);
 
                 return true;
-            }))
+            }), Events::PRE_DYNAMIC_GENERATE)
         ;
 
         $this->generator->expects($this->once())

--- a/tests/Unit/Routing/DynamicRouterTest.php
+++ b/tests/Unit/Routing/DynamicRouterTest.php
@@ -138,6 +138,9 @@ class DynamicRouterTest extends TestCase
         $this->assertEquals('http://test', $url);
     }
 
+    /**
+     * @group legacy
+     */
     public function testSupports()
     {
         $name = 'foo/bar';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | fix #248, #245
| License       | MIT
| Doc PR        | TODO

Continuation of the work by @acrobat

I realized that the VersatileRouterInterface is used to provide meaningful debug messages when something did not work, and i think for that its worth to keep it. So i only deprecated the `supports` method. And adjusted the debug message method to handle the new mode as well.