### PR TITLE
fix passing route object parameter to generator

### DIFF
--- a/src/ProviderBasedGenerator.php
+++ b/src/ProviderBasedGenerator.php
@@ -69,6 +69,11 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
             throw new RouteNotFoundException(sprintf('Route "%s" does not exist.', $name));
         }
 
+        // the parameter must be unset to avoid unexpected generation behaviour
+        if (array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)) {
+            unset($parameters[RouteObjectInterface::ROUTE_OBJECT]);
+        }
+
         // the Route has a cache of its own and is not recompiled as long as it does not get modified
         $compiledRoute = $route->compile();
         $hostTokens = $compiledRoute->getHostTokens();

--- a/src/ProviderBasedGenerator.php
+++ b/src/ProviderBasedGenerator.php
@@ -65,13 +65,9 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
             && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof SymfonyRoute
         ) {
             $route = $parameters[RouteObjectInterface::ROUTE_OBJECT];
+            unset($parameters[RouteObjectInterface::ROUTE_OBJECT]);
         } elseif (null === $route = $this->provider->getRouteByName($name)) {
             throw new RouteNotFoundException(sprintf('Route "%s" does not exist.', $name));
-        }
-
-        // the parameter must be unset to avoid unexpected generation behaviour
-        if (array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)) {
-            unset($parameters[RouteObjectInterface::ROUTE_OBJECT]);
         }
 
         // the Route has a cache of its own and is not recompiled as long as it does not get modified

--- a/tests/Unit/Routing/ProviderBasedGeneratorTest.php
+++ b/tests/Unit/Routing/ProviderBasedGeneratorTest.php
@@ -115,7 +115,7 @@ class ProviderBasedGeneratorTest extends TestCase
 
         $this->assertEquals('result_url', $url);
     }
-    
+
     /**
      * @group legacy
      *

--- a/tests/Unit/Routing/ProviderBasedGeneratorTest.php
+++ b/tests/Unit/Routing/ProviderBasedGeneratorTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Route as SymfonyRoute;
 
 class ProviderBasedGeneratorTest extends TestCase
 {
@@ -106,6 +107,15 @@ class ProviderBasedGeneratorTest extends TestCase
         $this->assertEquals('result_url', $url);
     }
 
+    public function testRemoveRouteObject(): void
+    {
+        $url = $this->generator->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, [
+            RouteObjectInterface::ROUTE_OBJECT => new Proxy('/path'),
+        ]);
+
+        $this->assertEquals('result_url', $url);
+    }
+    
     /**
      * @group legacy
      *
@@ -172,7 +182,12 @@ class TestableProviderBasedGenerator extends ProviderBasedGenerator
 {
     protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostTokens, array $requiredSchemes = [])
     {
-        return 'result_url';
+        $url = 'result_url';
+        if ($parameters && $query = http_build_query($parameters, '', '&', PHP_QUERY_RFC3986)) {
+            $url .= '?'.$query;
+        }
+
+        return $url;
     }
 }
 
@@ -187,4 +202,9 @@ class RouteObject implements RouteObjectInterface
     {
         return null;
     }
+}
+
+class Proxy extends SymfonyRoute
+{
+    public $__isInitialized__ = true;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

If the route is fetched over a relation from the database, it could be, that the route is still a proxy object (For lazy loading). If a url is generated with a proxy route object, then symfony will generate a string like ``/path?_route_object%5B__isInitialized__%5D=1``, because ``http_build_query`` also accept objects and generate a value if the object has a public property.

I think the parameter ``RouteObjectInterface::ROUTE_OBJECT`` is not necessary to pass it ``doGenerate``. So it should be unset if exists.

