### PR TITLE
Add $priority argument to ChainRouteCollection::add()

### DIFF
--- a/src/ChainRouteCollection.php
+++ b/src/ChainRouteCollection.php
@@ -66,13 +66,14 @@ class ChainRouteCollection extends RouteCollection
     /**
      * Adds a route.
      *
-     * @param string $name  The route name
-     * @param Route  $route A Route instance
+     * @param string $name     The route name
+     * @param Route  $route    A Route instance
+     * @param int    $priority The route priority
      */
-    public function add($name, Route $route)
+    public function add($name, Route $route, int $priority = 0)
     {
         $this->createInternalCollection();
-        $this->routeCollection->add($name, $route);
+        $this->routeCollection->add($name, $route, $priority);
     }
 
     /**


### PR DESCRIPTION
Since `symfony/routing` 5.1.0 https://github.com/symfony/routing/commit/4361dad278230d98f1beff5d0ef9478ec1790ea9 route collection's add method needs extra (3rd) argument

Ref https://github.com/symfony/symfony/pull/35608

| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any
