### PR TITLE
Remove calls to deprecated TestCase::at()

### DIFF
--- a/tests/Unit/DependencyInjection/Compiler/RegisterRouteEnhancersPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/RegisterRouteEnhancersPassTest.php
@@ -30,7 +30,7 @@ class RegisterRouteEnhancersPassTest extends TestCase
 
         $builder = $this->createMock(ContainerBuilder::class);
         $definition = new Definition('router');
-        $builder->expects($this->at(0))
+        $builder->expects($this->atLeastOnce())
             ->method('hasDefinition')
             ->with('cmf_routing.dynamic_router')
             ->will($this->returnValue(true))

--- a/tests/Unit/Routing/ChainRouterTest.php
+++ b/tests/Unit/Routing/ChainRouterTest.php
@@ -130,22 +130,12 @@ class ChainRouterTest extends TestCase
             ->setMethods(['sortRouters'])
             ->getMock();
         $router
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('sortRouters')
-            ->will(
-                $this->returnValue(
-                    [$high, $medium, $low]
-                )
-            )
-        ;
-        // The second time sortRouters() is called, we're supposed to get the newly added router ($highest)
-        $router
-            ->expects($this->at(1))
-            ->method('sortRouters')
-            ->will(
-                $this->returnValue(
-                    [$highest, $high, $medium, $low]
-                )
+            ->willReturnOnConsecutiveCalls(
+                [$high, $medium, $low],
+                // The second time sortRouters() is called, we're supposed to get the newly added router ($highest)
+                [$highest, $high, $medium, $low]
             )
         ;
 

--- a/tests/Unit/Routing/PagedRouteCollectionTest.php
+++ b/tests/Unit/Routing/PagedRouteCollectionTest.php
@@ -47,12 +47,16 @@ class PagedRouteCollectionTest extends TestCase
         }
         $names = array_keys($routes);
 
+        $with = [];
+        $will = [];
         foreach ($expectedCalls as $i => $range) {
-            $this->routeProvider->expects($this->at($i))
-              ->method('getRoutesPaged')
-              ->with($range[0], $range[1])
-              ->will($this->returnValue(array_slice($routes, $range[0], $range[1])));
+            $with[] = [$range[0], $range[1]];
+            $will[] = array_slice($routes, $range[0], $range[1]);
         }
+        $mocker = $this->routeProvider->expects($this->exactly(\count($expectedCalls)))
+            ->method('getRoutesPaged');
+        \call_user_func_array([$mocker, 'withConsecutive'], $with);
+        \call_user_func_array([$mocker, 'willReturnOnConsecutiveCalls'], $will);
 
         $route_collection = new PagedRouteCollection($this->routeProvider, $routesLoadedInParallel);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | https://github.com/sebastianbergmann/phpunit/issues/4297
