### PR TITLE
The RouterInterface is included in the ChainedRouterInterface

### DIFF
--- a/src/DynamicRouter.php
+++ b/src/DynamicRouter.php
@@ -27,7 +27,6 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RequestContextAwareInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * A flexible router accepting matcher and generator through injection and
@@ -36,7 +35,7 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Larry Garfield
  * @author David Buchmann
  */
-class DynamicRouter implements RouterInterface, RequestMatcherInterface, ChainedRouterInterface
+class DynamicRouter implements RequestMatcherInterface, ChainedRouterInterface
 {
     use RouteEnhancerTrait;
 

--- a/src/Event/RouterMatchEvent.php
+++ b/src/Event/RouterMatchEvent.php
@@ -30,7 +30,7 @@ class RouterMatchEvent extends Event
     }
 
     /**
-     * @return Request | null
+     * @return Request|null
      */
     public function getRequest()
     {

--- a/tests/Unit/Routing/ChainRouterTest.php
+++ b/tests/Unit/Routing/ChainRouterTest.php
@@ -476,14 +476,19 @@ class ChainRouterTest extends TestCase
     public function testMatchWithRequestMatchersNotFound()
     {
         $url = '/test';
-        $request = Request::create('/test');
+        $expected = Request::create('/test');
+        $expected->server->remove('REQUEST_TIME_FLOAT');
 
         $high = $this->createMock(RequestMatcher::class);
 
         $high
             ->expects($this->once())
             ->method('matchRequest')
-            ->with($request)
+            ->with($this->callback(function (Request $actual) use ($expected): bool {
+                $actual->server->remove('REQUEST_TIME_FLOAT');
+
+                return $actual == $expected;
+            }))
             ->will($this->throwException(new ResourceNotFoundException()))
         ;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Specifying the RouterInterface when also specifying the ChainedRouterInterface is redundant as the ChainedRouterInterface combines RouterInterface with other things.