### PR TITLE
Prepare major release and allow symfony 6

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -31,7 +31,10 @@ jobs:
                       symfony-require: "5.0.*"
 
                     - php-version: "8.0"
-                      symfony-require: "*"
+                      symfony-require: "5.0.*"
+
+                    - php-version: "8.0"
+                      symfony-require: "6.0.*"
 
         steps:
             - name: "Checkout project"

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "symfony/routing": "^4.4 || ^5.0",
-        "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/routing": "^4.4 || ^5.0 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0",
-        "symfony/config": "^4.4 || ^5.0",
-        "symfony/event-dispatcher": "^4.4 || ^5.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
+        "symfony/config": "^4.4 || ^5.0 || ^6.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
         "symfony-cmf/testing": "^3@dev"
     },
     "suggest": {

--- a/src/ChainRouteCollection.php
+++ b/src/ChainRouteCollection.php
@@ -43,17 +43,15 @@ class ChainRouteCollection extends RouteCollection
      *
      * @return \ArrayIterator An \ArrayIterator object for iterating over routes
      */
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->all());
     }
 
     /**
      * Gets the number of Routes in this collection.
-     *
-     * @return int The number of routes
      */
-    public function count()
+    public function count(): int
     {
         $count = 0;
         foreach ($this->routeCollections as $routeCollection) {
@@ -81,7 +79,7 @@ class ChainRouteCollection extends RouteCollection
      *
      * @return Route[] An array of routes
      */
-    public function all()
+    public function all(): array
     {
         $routeCollectionAll = new RouteCollection();
         foreach ($this->routeCollections as $routeCollection) {
@@ -95,10 +93,8 @@ class ChainRouteCollection extends RouteCollection
      * Gets a route by name.
      *
      * @param string $name The route name
-     *
-     * @return Route|null A Route instance or null when not found
      */
-    public function get($name)
+    public function get($name): ?Route
     {
         foreach ($this->routeCollections as $routeCollection) {
             $route = $routeCollection->get($name);
@@ -106,6 +102,8 @@ class ChainRouteCollection extends RouteCollection
                 return $route;
             }
         }
+
+        return null;
     }
 
     /**
@@ -240,7 +238,7 @@ class ChainRouteCollection extends RouteCollection
      *
      * @return ResourceInterface[] An array of resources
      */
-    public function getResources()
+    public function getResources(): array
     {
         if (0 === count($this->routeCollections)) {
             return [];

--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -67,9 +67,6 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
         $this->logger = $logger;
     }
 
-    /**
-     * @return RequestContext
-     */
     public function getContext(): RequestContext
     {
         if (!$this->context) {
@@ -215,21 +212,11 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
      *
      * @param string $name
      *
-     * The CMF routing system used to allow to pass route objects as $name to generate the route.
-     * Since Symfony 5.0, the UrlGeneratorInterface declares $name as string. We widen the contract
-     * for BC but deprecate passing non-strings.
-     * Instead, Pass the RouteObjectInterface::OBJECT_BASED_ROUTE_NAME as route name and the object
-     * in the parameters with key RouteObjectInterface::ROUTE_OBJECT.
-     *
      * Loops through all registered routers and returns a router if one is found.
      * It will always return the first route generated.
      */
     public function generate($name, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
-        if (is_object($name)) {
-            @trigger_error('Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.', E_USER_DEPRECATED);
-        }
-
         $debug = [];
 
         foreach ($this->all() as $router) {

--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -70,7 +70,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
     /**
      * @return RequestContext
      */
-    public function getContext()
+    public function getContext(): RequestContext
     {
         if (!$this->context) {
             $this->context = new RequestContext();
@@ -143,7 +143,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
      *
      * Note: You should use matchRequest if you can.
      */
-    public function match($pathinfo)
+    public function match($pathinfo): array
     {
         return $this->doMatch($pathinfo);
     }
@@ -153,7 +153,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
      *
      * Loops through all routes and tries to match the passed request.
      */
-    public function matchRequest(Request $request)
+    public function matchRequest(Request $request): array
     {
         return $this->doMatch($request->getPathInfo(), $request);
     }
@@ -213,7 +213,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
     /**
      * {@inheritdoc}
      *
-     * @param mixed $name
+     * @param string $name
      *
      * The CMF routing system used to allow to pass route objects as $name to generate the route.
      * Since Symfony 5.0, the UrlGeneratorInterface declares $name as string. We widen the contract
@@ -224,7 +224,7 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
      * Loops through all registered routers and returns a router if one is found.
      * It will always return the first route generated.
      */
-    public function generate($name, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function generate($name, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         if (is_object($name)) {
             @trigger_error('Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.', E_USER_DEPRECATED);

--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -217,6 +217,10 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
      */
     public function generate($name, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
+        if (!is_string($name)) {
+            throw new \InvalidArgumentException('The "$name" parameter should of type string.');
+        }
+
         $debug = [];
 
         foreach ($this->all() as $router) {

--- a/src/ContentAwareGenerator.php
+++ b/src/ContentAwareGenerator.php
@@ -65,6 +65,10 @@ class ContentAwareGenerator extends ProviderBasedGenerator
      */
     public function generate($name, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
+        if (!is_string($name)) {
+            throw new \InvalidArgumentException('The "$name" parameter should of type string.');
+        }
+
         if (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name) {
             if (array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)
                 && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof SymfonyRoute

--- a/src/ContentAwareGenerator.php
+++ b/src/ContentAwareGenerator.php
@@ -71,7 +71,7 @@ class ContentAwareGenerator extends ProviderBasedGenerator
      *
      * @throws RouteNotFoundException If there is no such route in the database
      */
-    public function generate($name, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function generate($name, $parameters = [], $absolute = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         if ($name instanceof SymfonyRoute) {
             @trigger_error('Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT` resp the content id with content_id.', E_USER_DEPRECATED);

--- a/src/DynamicRouter.php
+++ b/src/DynamicRouter.php
@@ -165,6 +165,10 @@ class DynamicRouter implements RequestMatcherInterface, ChainedRouterInterface
      */
     public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
+        if (!is_string($name)) {
+            throw new \InvalidArgumentException('The "$name" parameter should of type string.');
+        }
+
         if ($this->eventDispatcher) {
             $event = new RouterGenerateEvent($name, $parameters, $referenceType);
             $this->eventDispatcher->dispatch($event, Events::PRE_DYNAMIC_GENERATE);

--- a/src/DynamicRouter.php
+++ b/src/DynamicRouter.php
@@ -159,11 +159,11 @@ class DynamicRouter implements RequestMatcherInterface, ChainedRouterInterface
      * Instead, Pass the RouteObjectInterface::OBJECT_BASED_ROUTE_NAME as route name and the object
      * in the parameters with key RouteObjectInterface::ROUTE_OBJECT.
      *
-     * @param string|Route $name The name of the route or the Route instance
+     * @param string $name The name of the route
      *
      * @throws RouteNotFoundException if route doesn't exist
      */
-    public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         if (is_object($name)) {
             @trigger_error('Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT', E_USER_DEPRECATED);
@@ -213,7 +213,7 @@ class DynamicRouter implements RequestMatcherInterface, ChainedRouterInterface
      *
      * @api
      */
-    public function match($pathinfo)
+    public function match($pathinfo): array
     {
         @trigger_error(__METHOD__.'() is deprecated since version 1.3 and will be removed in 2.0. Use matchRequest() instead.', E_USER_DEPRECATED);
 
@@ -252,7 +252,7 @@ class DynamicRouter implements RequestMatcherInterface, ChainedRouterInterface
      * @throws MethodNotAllowedException If a matching resource was found but
      *                                   the request method is not allowed
      */
-    public function matchRequest(Request $request)
+    public function matchRequest(Request $request): array
     {
         if ($this->eventDispatcher) {
             $event = new RouterMatchEvent($request);
@@ -294,7 +294,7 @@ class DynamicRouter implements RequestMatcherInterface, ChainedRouterInterface
      *
      * @api
      */
-    public function getContext()
+    public function getContext(): RequestContext
     {
         return $this->context;
     }

--- a/src/DynamicRouter.php
+++ b/src/DynamicRouter.php
@@ -165,10 +165,6 @@ class DynamicRouter implements RequestMatcherInterface, ChainedRouterInterface
      */
     public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
-        if (is_object($name)) {
-            @trigger_error('Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT', E_USER_DEPRECATED);
-        }
-
         if ($this->eventDispatcher) {
             $event = new RouterGenerateEvent($name, $parameters, $referenceType);
             $this->eventDispatcher->dispatch($event, Events::PRE_DYNAMIC_GENERATE);

--- a/src/LazyRouteCollection.php
+++ b/src/LazyRouteCollection.php
@@ -32,17 +32,15 @@ class LazyRouteCollection extends RouteCollection
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->all());
     }
 
     /**
      * Gets the number of Routes in this collection.
-     *
-     * @return int The number of routes
      */
-    public function count()
+    public function count(): int
     {
         return count($this->all());
     }
@@ -52,7 +50,7 @@ class LazyRouteCollection extends RouteCollection
      *
      * @return Route[] An array of routes
      */
-    public function all()
+    public function all(): array
     {
         return $this->provider->getRoutesByNames(null);
     }
@@ -61,15 +59,13 @@ class LazyRouteCollection extends RouteCollection
      * Gets a route by name.
      *
      * @param string $name The route name
-     *
-     * @return Route|null A Route instance or null when not found
      */
-    public function get($name)
+    public function get($name): ?Route
     {
         try {
             return $this->provider->getRouteByName($name);
         } catch (RouteNotFoundException $e) {
-            return;
+            return null;
         }
     }
 }

--- a/src/NestedMatcher/NestedMatcher.php
+++ b/src/NestedMatcher/NestedMatcher.php
@@ -135,7 +135,7 @@ class NestedMatcher implements RequestMatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function matchRequest(Request $request)
+    public function matchRequest(Request $request): array
     {
         $collection = $this->routeProvider->getRouteCollectionForRequest($request);
         if (!count($collection)) {

--- a/src/NestedMatcher/UrlMatcher.php
+++ b/src/NestedMatcher/UrlMatcher.php
@@ -43,7 +43,7 @@ class UrlMatcher extends SymfonyUrlMatcher implements FinalMatcherInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAttributes(Route $route, $name, array $attributes)
+    protected function getAttributes(Route $route, $name, array $attributes): array
     {
         if ($route instanceof RouteObjectInterface && is_string($route->getRouteKey())) {
             $name = $route->getRouteKey();

--- a/src/PagedRouteCollection.php
+++ b/src/PagedRouteCollection.php
@@ -69,8 +69,9 @@ class PagedRouteCollection implements \Iterator, \Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->currentRoutes);
@@ -79,7 +80,7 @@ class PagedRouteCollection implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function next()
+    public function next(): void
     {
         $result = next($this->currentRoutes);
         if (false === $result) {
@@ -89,8 +90,9 @@ class PagedRouteCollection implements \Iterator, \Countable
     }
 
     /**
-     * {@inheritdoc}
+     * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->currentRoutes);
@@ -99,15 +101,15 @@ class PagedRouteCollection implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
-        return key($this->currentRoutes);
+        return null !== key($this->currentRoutes);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->current = 0;
         $this->currentRoutes = null;

--- a/src/ProviderBasedGenerator.php
+++ b/src/ProviderBasedGenerator.php
@@ -43,23 +43,10 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
 
     /**
      * {@inheritdoc}
-     *
-     * The CMF routing system used to allow to pass route objects as $name to generate the route.
-     * Since Symfony 5.0, the UrlGeneratorInterface declares $name as string. We widen the contract
-     * for BC but deprecate passing non-strings.
-     * Instead, Pass the RouteObjectInterface::OBJECT_BASED_ROUTE_NAME as route name and the object
-     * in the parameters with key RouteObjectInterface::ROUTE_OBJECT.
-     *
-     * @param mixed $name
      */
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string
     {
-        if (is_object($name)) {
-            @trigger_error('Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`', E_USER_DEPRECATED);
-        }
-        if ($name instanceof SymfonyRoute) {
-            $route = $name;
-        } elseif (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name
+        if (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name
             && array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)
             && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof SymfonyRoute
         ) {

--- a/src/ProviderBasedGenerator.php
+++ b/src/ProviderBasedGenerator.php
@@ -46,6 +46,10 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
      */
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string
     {
+        if (!is_string($name)) {
+            throw new \InvalidArgumentException('The "$name" parameter should of type string.');
+        }
+
         if (RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name
             && array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)
             && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof SymfonyRoute

--- a/src/ProviderBasedGenerator.php
+++ b/src/ProviderBasedGenerator.php
@@ -52,7 +52,7 @@ class ProviderBasedGenerator extends UrlGenerator implements VersatileGeneratorI
      *
      * @param mixed $name
      */
-    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string
     {
         if (is_object($name)) {
             @trigger_error('Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`', E_USER_DEPRECATED);

--- a/tests/Unit/Candidates/CandidatesTest.php
+++ b/tests/Unit/Candidates/CandidatesTest.php
@@ -29,6 +29,8 @@ class CandidatesTest extends TestCase
 
     /**
      * Nothing should be called on the query builder.
+     *
+     * @doesNotPerformAssertions
      */
     public function testRestrictQuery()
     {

--- a/tests/Unit/Routing/ChainRouterTest.php
+++ b/tests/Unit/Routing/ChainRouterTest.php
@@ -709,6 +709,23 @@ class ChainRouterTest extends TestCase
         $this->assertEquals(['high', 'low'], $names);
     }
 
+    public function testGenerateWithNameParameterObject()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $parameters = ['test' => 'value'];
+        $defaultRouter = $this->createMock(RouterInterface::class);
+
+        $defaultRouter
+            ->expects($this->never())
+            ->method('generate')
+        ;
+
+        $this->router->add($defaultRouter, 200);
+
+        $this->router->generate(new \stdClass(), $parameters);
+    }
+
     /**
      * @group legacy
      */

--- a/tests/Unit/Routing/ChainRouterTest.php
+++ b/tests/Unit/Routing/ChainRouterTest.php
@@ -23,7 +23,6 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\Loader\ObjectRouteLoader;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
@@ -606,111 +605,6 @@ class ChainRouterTest extends TestCase
 
         $this->expectException(RouteNotFoundException::class);
         $this->router->generate($name, $parameters);
-    }
-
-    /**
-     * Route is an object but no versatile generator around to do the debug message.
-     *
-     * @group legacy
-     * @expectedDeprecation Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.
-     */
-    public function testGenerateObjectNotFound()
-    {
-        if (!class_exists(ObjectRouteLoader::class)) {
-            $this->markTestSkipped('Symfony 5 would throw a TypeError.');
-        }
-
-        $name = new \stdClass();
-        $parameters = ['test' => 'value'];
-
-        $defaultRouter = $this->createMock(RouterInterface::class);
-
-        $defaultRouter
-            ->expects($this->never())
-            ->method('generate')
-        ;
-
-        $this->router->add($defaultRouter, 200);
-
-        $this->expectException(RouteNotFoundException::class);
-        $this->router->generate($name, $parameters);
-    }
-
-    /**
-     * A versatile router will generate the debug message.
-     *
-     * @group legacy
-     * @expectedDeprecation Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.
-     */
-    public function testGenerateObjectNotFoundVersatile()
-    {
-        if (!class_exists(ObjectRouteLoader::class)) {
-            $this->markTestSkipped('Symfony 5 would throw a TypeError.');
-        }
-
-        $name = new \stdClass();
-        $parameters = ['test' => 'value'];
-
-        $chainedRouter = $this->createMock(VersatileRouter::class);
-        $chainedRouter
-            ->expects($this->once())
-            ->method('supports')
-            ->will($this->returnValue(true))
-        ;
-        $chainedRouter->expects($this->once())
-            ->method('generate')
-            ->with($name, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH)
-            ->will($this->throwException(new RouteNotFoundException()))
-        ;
-        $chainedRouter->expects($this->once())
-            ->method('getRouteDebugMessage')
-            ->with($name, $parameters)
-            ->will($this->returnValue('message'))
-        ;
-
-        $this->router->add($chainedRouter, 10);
-
-        $this->expectException(RouteNotFoundException::class);
-        $this->router->generate($name, $parameters);
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.
-     */
-    public function testGenerateObjectName()
-    {
-        if (!class_exists(ObjectRouteLoader::class)) {
-            $this->markTestSkipped('Symfony 5 would throw a TypeError.');
-        }
-
-        $name = new \stdClass();
-        $parameters = ['test' => 'value'];
-
-        $defaultRouter = $this->createMock(RouterInterface::class);
-        $chainedRouter = $this->createMock(VersatileRouter::class);
-
-        $defaultRouter
-            ->expects($this->never())
-            ->method('generate')
-        ;
-        $chainedRouter
-            ->expects($this->once())
-            ->method('supports')
-            ->will($this->returnValue(true))
-        ;
-        $chainedRouter
-            ->expects($this->once())
-            ->method('generate')
-            ->with($name, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH)
-            ->will($this->returnValue($name))
-        ;
-
-        $this->router->add($defaultRouter, 200);
-        $this->router->add($chainedRouter, 100);
-
-        $result = $this->router->generate($name, $parameters);
-        $this->assertEquals($name, $result);
     }
 
     /**

--- a/tests/Unit/Routing/ContentAwareGeneratorTest.php
+++ b/tests/Unit/Routing/ContentAwareGeneratorTest.php
@@ -507,6 +507,13 @@ class ContentAwareGeneratorTest extends TestCase
         $this->assertStringContainsString('Route aware content Symfony\Cmf\Component\Routing\Tests\Routing\RouteAware', $this->generator->getRouteDebugMessage(new RouteAware()));
         $this->assertStringContainsString('/some/content', $this->generator->getRouteDebugMessage('/some/content'));
     }
+
+    public function testGenerateWithNameParameterObject(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->generator->generate(new \stdClass());
+    }
 }
 
 /**

--- a/tests/Unit/Routing/ContentAwareGeneratorTest.php
+++ b/tests/Unit/Routing/ContentAwareGeneratorTest.php
@@ -559,7 +559,7 @@ class ContentAwareGeneratorTest extends TestCase
  */
 class TestableContentAwareGenerator extends ContentAwareGenerator
 {
-    protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostTokens, array $requiredSchemes = [])
+    protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostTokens, array $requiredSchemes = []): string
     {
         return 'result_url';
     }

--- a/tests/Unit/Routing/ContentAwareGeneratorTest.php
+++ b/tests/Unit/Routing/ContentAwareGeneratorTest.php
@@ -21,7 +21,6 @@ use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
 use Symfony\Cmf\Component\Routing\Tests\Unit\Routing\RouteMock;
 use Symfony\Component\Routing\CompiledRoute;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
-use Symfony\Component\Routing\Loader\ObjectRouteLoader;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 
@@ -38,7 +37,7 @@ class ContentAwareGeneratorTest extends TestCase
     private $routeDocument;
 
     /**
-     * @var CompiledRoute|MockObject
+     * @var CompiledRoute
      */
     private $routeCompiled;
 
@@ -65,36 +64,11 @@ class ContentAwareGeneratorTest extends TestCase
             ->setMethods(['compile', 'getContent'])
             ->getMock();
 
-        $this->routeCompiled = $this->createMock(CompiledRoute::class);
+        $this->routeCompiled = new CompiledRoute('', '', [], []);
         $this->provider = $this->createMock(RouteProviderInterface::class);
         $this->context = $this->createMock(RequestContext::class);
 
         $this->generator = new TestableContentAwareGenerator($this->provider);
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`.
-     */
-    public function testGenerateFromContent(): void
-    {
-        if (!class_exists(ObjectRouteLoader::class)) {
-            $this->markTestSkipped('Symfony 5 would throw a TypeError.');
-        }
-
-        $this->provider->expects($this->never())
-            ->method('getRouteByName')
-        ;
-        $this->contentDocument->expects($this->once())
-            ->method('getRoutes')
-            ->willReturn([$this->routeDocument])
-        ;
-        $this->routeDocument->expects($this->once())
-            ->method('compile')
-            ->willReturn($this->routeCompiled)
-        ;
-
-        $this->assertEquals('result_url', $this->generator->generate($this->contentDocument));
     }
 
     public function testGenerateFromContentInParameters(): void
@@ -232,10 +206,6 @@ class ContentAwareGeneratorTest extends TestCase
             ->method('getDefault')
             ->with('_locale')
             ->willReturn('en')
-        ;
-        $this->routeCompiled->expects($this->any())
-            ->method('getVariables')
-            ->willReturn([])
         ;
 
         $generated = $this->generator->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, ['_locale' => 'en', RouteObjectInterface::ROUTE_OBJECT => $route]);
@@ -401,21 +371,6 @@ class ContentAwareGeneratorTest extends TestCase
     {
         $this->expectException(RouteNotFoundException::class);
         $this->generator->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, [RouteObjectInterface::ROUTE_OBJECT => $this]);
-    }
-
-    /**
-     * Generate with an object that is neither a route nor route aware.
-     *
-     * @group legacy
-     */
-    public function testGenerateInvalidContentLegacy(): void
-    {
-        if (!class_exists(ObjectRouteLoader::class)) {
-            $this->markTestSkipped('Symfony 5 would throw a TypeError.');
-        }
-
-        $this->expectException(RouteNotFoundException::class);
-        $this->generator->generate($this);
     }
 
     /**

--- a/tests/Unit/Routing/ProviderBasedGeneratorTest.php
+++ b/tests/Unit/Routing/ProviderBasedGeneratorTest.php
@@ -180,7 +180,7 @@ class ProviderBasedGeneratorTest extends TestCase
  */
 class TestableProviderBasedGenerator extends ProviderBasedGenerator
 {
-    protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostTokens, array $requiredSchemes = [])
+    protected function doGenerate(array $variables, array $defaults, array $requirements, array $tokens, array $parameters, string $name, int $referenceType, array $hostTokens, array $requiredSchemes = []): string
     {
         $url = 'result_url';
         if ($parameters && $query = http_build_query($parameters, '', '&', PHP_QUERY_RFC3986)) {

--- a/tests/Unit/Routing/ProviderBasedGeneratorTest.php
+++ b/tests/Unit/Routing/ProviderBasedGeneratorTest.php
@@ -155,6 +155,13 @@ class ProviderBasedGeneratorTest extends TestCase
             'number' => 'string',
         ]);
     }
+
+    public function testGenerateWithNameParameterObject(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->generator->generate(new \stdClass());
+    }
 }
 
 /**

--- a/tests/Unit/Routing/ProviderBasedGeneratorTest.php
+++ b/tests/Unit/Routing/ProviderBasedGeneratorTest.php
@@ -31,7 +31,7 @@ class ProviderBasedGeneratorTest extends TestCase
     private $routeDocument;
 
     /**
-     * @var CompiledRoute|MockObject
+     * @var CompiledRoute
      */
     private $routeCompiled;
 
@@ -53,7 +53,7 @@ class ProviderBasedGeneratorTest extends TestCase
     public function setUp(): void
     {
         $this->routeDocument = $this->createMock(Route::class);
-        $this->routeCompiled = $this->createMock(CompiledRoute::class);
+        $this->routeCompiled = new CompiledRoute('', '', [], []);
         $this->provider = $this->createMock(RouteProviderInterface::class);
         $this->context = $this->createMock(RequestContext::class);
 
@@ -116,24 +116,6 @@ class ProviderBasedGeneratorTest extends TestCase
         $this->assertEquals('result_url', $url);
     }
 
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation Passing an object as route name is deprecated since version 2.3. Pass the `RouteObjectInterface::OBJECT_BASED_ROUTE_NAME` as route name and the object in the parameters with key `RouteObjectInterface::ROUTE_OBJECT`
-     */
-    public function testGenerateFromRouteLegacy(): void
-    {
-        $this->provider->expects($this->never())
-            ->method('getRouteByName')
-        ;
-        $this->routeDocument->expects($this->once())
-            ->method('compile')
-            ->willReturn($this->routeCompiled)
-        ;
-
-        $this->assertEquals('result_url', $this->generator->generate($this->routeDocument));
-    }
-
     public function testSupports(): void
     {
         $this->assertTrue($this->generator->supports('foo/bar'));
@@ -180,7 +162,7 @@ class ProviderBasedGeneratorTest extends TestCase
  */
 class TestableProviderBasedGenerator extends ProviderBasedGenerator
 {
-    protected function doGenerate(array $variables, array $defaults, array $requirements, array $tokens, array $parameters, string $name, int $referenceType, array $hostTokens, array $requiredSchemes = []): string
+    protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostTokens, $requiredSchemes = []): string
     {
         $url = 'result_url';
         if ($parameters && $query = http_build_query($parameters, '', '&', PHP_QUERY_RFC3986)) {

--- a/tests/Unit/Routing/RouteMock.php
+++ b/tests/Unit/Routing/RouteMock.php
@@ -28,7 +28,7 @@ class RouteMock extends SymfonyRoute implements RouteObjectInterface
         return;
     }
 
-    public function getDefaults()
+    public function getDefaults(): array
     {
         $defaults = [];
         if (null !== $this->locale) {
@@ -38,7 +38,7 @@ class RouteMock extends SymfonyRoute implements RouteObjectInterface
         return $defaults;
     }
 
-    public function getRequirement($key)
+    public function getRequirement($key): ?string
     {
         if ('_locale' !== $key) {
             throw new \Exception();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        |

This PR adds some required typehints for symfony 6 and to make this change easier I suggest to release this PR as a new major release. It's easy for project to upgrade/support the upcoming major, as only a previous deprecation is removed and all older symfony versions are still supported (+ sf6 support)
