### PR TITLE
 Update composer branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,5 @@
         "psr-4": {
             "Symfony\\Cmf\\Component\\Routing\\Tests\\": "tests/"
         }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.x-dev"
-        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | default branch for new features / the branch of the current release for fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

There is a `master` which alias to 3.x and a `3.x` branch. I think it would be best to remove the `master` branch. Else we should remove the alias like here for the composer.json
