### PR TITLE
fix(security): request object leakage

### DIFF
--- a/src/ChainRouter.php
+++ b/src/ChainRouter.php
@@ -173,11 +173,9 @@ class ChainRouter implements ChainRouterInterface, WarmableInterface
             }
         }
 
-        $info = $request
-            ? "this request\n$request"
-            : "url '$pathinfo'";
+        $info = $request ? $request->getPathInfo() : $pathinfo;
 
-        throw $methodNotAllowed ?: new ResourceNotFoundException("None of the routers in the chain matched $info");
+        throw $methodNotAllowed ?: new ResourceNotFoundException("None of the routers in the chain matched url $info");
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | patch versions for both 2.x and 3.x branches
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #280
| License       | MIT
| Doc PR        | 


> matching can happen on other things than the path and method. i think we should adjust the message a bit to not lead people to only look at the path and be confused.

@dbu Hey 👋. I've read the above message from #280, but just wanted to fix a security issue at hand instead of thinking what should be the proper exception message.